### PR TITLE
feat: landing page add slack and google groups link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,10 +129,22 @@ const config = {
             title: 'Community',
             items: [
               {
+                label: 'Slack Channel',
+                href: 'https://cloud-native.slack.com/messages/dragonfly/',
+              },
+              {
                 html: '<div class="dingtalk"> <a class="dingtalk-label">DingTalk</a> <a class="dingtalk-img" aria-label="DingTalk"><img src="https://raw.githubusercontent.com/dragonflyoss/d7y.io/main/static/img/landing/dingtalk.jpg" alt="DingTalk Group"></div>',
               },
               {
-                label: 'Discussions',
+                label: 'Discussion Group',
+                href: 'mailto:dragonfly-discuss@googlegroups.com',
+              },
+              {
+                label: 'Developer Group',
+                href: 'mailto:dragonfly-developers@googlegroups.com',
+              },
+              {
+                label: 'Github Discussions',
                 href: 'https://github.com/dragonflyoss/Dragonfly2/discussions',
               },
               {

--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -50,5 +50,21 @@
   "link.item.label.Others": {
     "message": "其他",
     "description": "The label of footer link with label=Others linking to /docs/others/faqs"
+  },
+  "link.item.label.Slack Channel": {
+    "message": "Slack Channel",
+    "description": "The label of footer link with label=Slack Channel linking to https://cloud-native.slack.com/messages/dragonfly/"
+  },
+  "link.item.label.Discussion Group": {
+    "message": "Discussion Group",
+    "description": "The label of footer link with label=Discussion Group linking to mailto:dragonfly-discuss@googlegroups.com"
+  },
+  "link.item.label.Developer Group": {
+    "message": "Developer Group",
+    "description": "The label of footer link with label=Developer Group linking to mailto:dragonfly-developers@googlegroups.com"
+  },
+  "link.item.label.Github Discussions": {
+    "message": "Github Discussions",
+    "description": "The label of footer link with label=Github Discussions linking to https://github.com/dragonflyoss/Dragonfly2/discussions"
   }
 }


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Landing page add slack and google groups link.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
