### PR TITLE
fix: dfdaemon config add proxy basicAuth example & fix typo

### DIFF
--- a/docs/reference/configuration/dfdaemon.md
+++ b/docs/reference/configuration/dfdaemon.md
@@ -291,4 +291,8 @@ proxy:
       regx:
       # port that need to be added to the whitelist
       ports:
+  # setup basic auth for proxy
+  basicAuth:
+    username: "admin"
+    password: "password"
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/configuration/dfdaemon.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/configuration/dfdaemon.md
@@ -125,7 +125,7 @@ download:
       tlsVerify: true
       tlsConfig: null
     # 下载服务监听地址，dfget 下载文件将通过该地址连接到 daemon
-    # 目前是支持 unix domain socket
+    # 目前只支持 unix domain socket
     unixListen:
       # linux 上默认路径为 /var/run/dfdaemon.sock
       # macos(仅开发、测试), 默认目录是 /tmp/dfdaemon.sock
@@ -270,4 +270,8 @@ proxy:
       ports:
       # - 80
       # - 443
+  # 为 proxy 设置基础认证
+  basicAuth:
+    username: "admin"
+    password: "password"
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.0.3/reference/configuration/dfdaemon.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.0.3/reference/configuration/dfdaemon.md
@@ -123,7 +123,7 @@ download:
       tlsVerify: true
       tlsConfig: null
     # 下载服务监听地址，dfget 下载文件将通过该地址连接到 daemon
-    # 目前是支持 unix domain socket
+    # 目前只支持 unix domain socket
     unixListen:
       # linux 上默认路径为 /var/run/dfdaemon.sock
       # macos(仅开发、测试), 默认目录是 /tmp/dfdaemon.sock
@@ -268,4 +268,8 @@ proxy:
       ports:
       # - 80
       # - 443
+  # 为 proxy 设置基础认证
+  basicAuth:
+    username: "admin"
+    password: "password"
 ```

--- a/versioned_docs/version-v2.0.3/reference/configuration/dfdaemon.md
+++ b/versioned_docs/version-v2.0.3/reference/configuration/dfdaemon.md
@@ -291,4 +291,8 @@ proxy:
       regx:
       # port that need to be added to the whitelist
       ports:
+  # setup basic auth for proxy
+  basicAuth:
+    username: "admin"
+    password: "password"
 ```


### PR DESCRIPTION
fix: dfdaemon config add basicAuth example & fix typo

Signed-off-by: LetFu <letfu@outlook.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

There is auth logic in the proxy code, but it is not reflected in the dfdaemon config example page.
```bash
# For http proxy mode, use like:
HTTP_PROXY=http://admin:password@127.0.0.1:65001
HTTPS_PROXY=http://admin:password@127.0.0.1:65001

# For mirror mode in multiple registries, use like:
server = "https://registry-1.docker.io"

[host."http://127.0.0.1:65001"]
  capabilities = ["pull", "resolve"]
  [host."http://127.0.0.1:65001".header]
    X-Dragonfly-Registry = ["https://registry-1.docker.io"]
    # Get the base64 string: printf "admin:password" | base64
    Proxy-Authorization = "Basic YWRtaW46cGFzc3dvcmQ="
```

<!--- Describe your changes in detail -->

## Related Issue

#97 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
