### PR TITLE
fix: update docker compose command

### DIFF
--- a/docs/getting-started/quick-start/docker-compose.md
+++ b/docs/getting-started/quick-start/docker-compose.md
@@ -43,10 +43,11 @@ Add or update the following configuration items in the configuration file `/etc/
 }
 ```
 
-Restart Docker Daemon
+Restart Docker Daemon and Dragonfly
 
 ```bash
 systemctl restart docker
+./run.sh
 ```
 
 > **Tips**：
@@ -70,7 +71,7 @@ docker pull nginx:latest
 You can verify that the nginx image is transferred through Dragonfly by executing the following command.
 
 ```bash
-docker exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
+docker compose exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
 ```
 
 If the above command has something like

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start/docker-compose.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start/docker-compose.md
@@ -40,10 +40,11 @@ export IP=<host ip>
 }
 ```
 
-重启 Docker Daemon
+重启 Docker Daemon 和 Dragonfly
 
 ```bash
 systemctl restart docker
+./run.sh
 ```
 
 > **提示**：
@@ -67,7 +68,7 @@ docker pull nginx:latest
 您可以通过执行以下命令，检验 nginx 镜像是否通过 Dragonfly 来传输完成。
 
 ```bash
-docker exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
+docker compose exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
 ```
 
 如果以上命令有诸如

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.0.6/getting-started/quick-start/docker-compose.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.0.6/getting-started/quick-start/docker-compose.md
@@ -40,10 +40,11 @@ export IP=<host ip>
 }
 ```
 
-重启 Docker Daemon
+重启 Docker Daemon 和 Dragonfly
 
 ```bash
 systemctl restart docker
+./run.sh
 ```
 
 > **提示**：
@@ -67,7 +68,7 @@ docker pull nginx:latest
 您可以通过执行以下命令，检验 nginx 镜像是否通过 Dragonfly 来传输完成。
 
 ```bash
-docker exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
+docker compose exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
 ```
 
 如果以上命令有诸如

--- a/versioned_docs/version-v2.0.6/getting-started/quick-start/docker-compose.md
+++ b/versioned_docs/version-v2.0.6/getting-started/quick-start/docker-compose.md
@@ -43,10 +43,11 @@ Add or update the following configuration items in the configuration file `/etc/
 }
 ```
 
-Restart Docker Daemon
+Restart Docker Daemon and Dragonfly
 
 ```bash
 systemctl restart docker
+./run.sh
 ```
 
 > **Tips**：
@@ -70,7 +71,7 @@ docker pull nginx:latest
 You can verify that the nginx image is transferred through Dragonfly by executing the following command.
 
 ```bash
-docker exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
+docker compose exec dfdaemon grep "peer task done" /var/log/dragonfly/daemon/core.log
 ```
 
 If the above command has something like


### PR DESCRIPTION
Signed-off-by: Qinqi Qu <quqinqi@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

- The `docker exec` command could not find the container named dfdaemon and should be replaced with `docker compose exec`.
- After `systemctl restart docker`, the already started dragonfly will not work properly and need to be restarted with `./run.sh`


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
