### PR TITLE
docs: added spaces after commas in Milestones

### DIFF
--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -420,16 +420,16 @@
   "Dragonfly 1.x": {
     "message": "Dragonfly 1.x"
   },
-  "In November 2017,the Dragonfly 1.x project was open sourced,and was selected and put into production use by many internet companies.": {
+  "In November 2017, the Dragonfly 1.x project was open sourced,and was selected and put into production use by many internet companies.": {
     "message": "2017年11月，Dragonfly 1.x 项目正式开源，被许多大规模互联网公司选用并投入生产使用。"
   },
-  "In October 2018,it entered the CNCF Sandbox, becoming the third project in China to enter the CNCF Sandbox.": {
+  "In October 2018, it entered the CNCF Sandbox, becoming the third project in China to enter the CNCF Sandbox.": {
     "message": "2018年10月，正式进入 CNCF Sandbox，成为中国第三个进入CNCF Sandbox 项目。"
   },
   "CNCF Incubating": {
     "message": "CNCF Incubating"
   },
-  "In April 2020,the CNCF TOC voted to accept Dragonfly as an official entry into CNCF Incubating.": {
+  "In April 2020, the CNCF TOC voted to accept Dragonfly as an official entry into CNCF Incubating.": {
     "message": "2020年4月由 CNCF TOC 投票决定接受 Dragonfly 正式进入。CNCF Incubating。"
   },
   "Dragonfly 2": {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -196,7 +196,7 @@ export default function Home() {
       cardTitle: <Translate> Dragonfly 1.x</Translate>,
       cardContent: (
         <Translate>
-          In November 2017,the Dragonfly 1.x project was open sourced,and was selected and put into production use by
+          In November 2017, the Dragonfly 1.x project was open sourced,and was selected and put into production use by
           many internet companies.
         </Translate>
       ),
@@ -205,7 +205,7 @@ export default function Home() {
       cardTitle: <Translate> CNCF SandBox</Translate>,
       cardContent: (
         <Translate>
-          In October 2018,it entered the CNCF Sandbox, becoming the third project in China to enter the CNCF Sandbox.
+          In October 2018, it entered the CNCF Sandbox, becoming the third project in China to enter the CNCF Sandbox.
         </Translate>
       ),
     },
@@ -213,7 +213,7 @@ export default function Home() {
       cardTitle: <Translate> CNCF Incubating</Translate>,
       cardContent: (
         <Translate>
-          In April 2020,the CNCF TOC voted to accept Dragonfly as an official entry into CNCF Incubating.
+          In April 2020, the CNCF TOC voted to accept Dragonfly as an official entry into CNCF Incubating.
         </Translate>
       ),
     },


### PR DESCRIPTION
## Added space after commas in milestones

Some of the milestones were grammatically incorrect because there was no space after commas. This commit adds the space after commas 

## Related Issue
https://github.com/dragonflyoss/d7y.io/issues/12

## Motivation and Context

This change will improve the global website of d7y.io by improving its grammar