### PR TITLE
Add docs for directory mode configuration

### DIFF
--- a/docs/reference/configuration/dfdaemon.md
+++ b/docs/reference/configuration/dfdaemon.md
@@ -21,6 +21,10 @@ gcInterval: 1m0s
 # In macos(just for testing), default value is /Users/$USER/.dragonfly.
 workHome: ''
 
+# workHomeMode is used to set the file mode bits for the workHome directory
+# The default is 0755
+workHomeMode: 0755
+
 # logDir is the log directory.
 # In linux, default value is /var/log/dragonfly.
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
@@ -31,6 +35,10 @@ logDir: ''
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
 cacheDir: ''
 
+# cacheDirMode is used to set the file mode bits for the cacheDir directory
+# The default is 0755
+cacheDirMode: 0755
+
 # pluginDir is the plugin directory.
 # In linux, default value is /usr/local/dragonfly/plugins.
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
@@ -40,6 +48,10 @@ pluginDir: ''
 # In linux, default value is /var/lib/dragonfly.
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
 dataDir: ''
+
+# dataDirMode is used to set the file mode bits for the dataDir directory
+# The default is 0755
+dataDirMode: 0755
 
 # When daemon exit, keep peer task data or not.
 # it is usefully when upgrade daemon service, all local cache will be saved

--- a/docs/reference/configuration/dfdaemon.md
+++ b/docs/reference/configuration/dfdaemon.md
@@ -21,8 +21,8 @@ gcInterval: 1m0s
 # In macos(just for testing), default value is /Users/$USER/.dragonfly.
 workHome: ''
 
-# workHomeMode is used to set the file mode bits for the workHome directory
-# The default is 0755
+# workHomeMode is used to set the file mode bits for the workHome directory.
+# The default is 0755.
 workHomeMode: 0755
 
 # logDir is the log directory.
@@ -35,8 +35,8 @@ logDir: ''
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
 cacheDir: ''
 
-# cacheDirMode is used to set the file mode bits for the cacheDir directory
-# The default is 0755
+# cacheDirMode is used to set the file mode bits for the cacheDir directory.
+# The default is 0755.
 cacheDirMode: 0755
 
 # pluginDir is the plugin directory.
@@ -49,8 +49,8 @@ pluginDir: ''
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
 dataDir: ''
 
-# dataDirMode is used to set the file mode bits for the dataDir directory
-# The default is 0755
+# dataDirMode is used to set the file mode bits for the dataDir directory.
+# The default is 0755.
 dataDirMode: 0755
 
 # When daemon exit, keep peer task data or not.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/configuration/dfdaemon.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/configuration/dfdaemon.md
@@ -20,6 +20,10 @@ gcInterval: 1m0s
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly。
 workHome: ''
 
+# workHomeMode is used to set the file mode bits for the workHome directory.
+# The default is 0755.
+workHomeMode: 0755
+
 # 服务的日志目录。
 # Linux 上默认目录 /var/log/dragonfly。
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/logs。
@@ -30,6 +34,10 @@ logDir: ''
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/cache。
 cacheDir: ''
 
+# cacheDirMode is used to set the file mode bits for the cacheDir directory.
+# The default is 0755.
+cacheDirMode: 0755
+
 # 服务的插件目录。
 # Linux 上默认目录 /usr/local/dragonfly/plugins。
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/plugins。
@@ -39,6 +47,10 @@ pluginDir: ''
 # Linux 上默认目录为 /var/lib/dragonfly。
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/data/。
 dataDir: ''
+
+# dataDirMode is used to set the file mode bits for the dataDir directory.
+# The default is 0755.
+dataDirMode: 0755
 
 # 当 daemon 退出是, 是否保存缓存数据。
 # 保留缓存数据在升级 daemon 的时候比较有用。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.1.0/reference/configuration/dfdaemon.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.1.0/reference/configuration/dfdaemon.md
@@ -20,6 +20,10 @@ gcInterval: 1m0s
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly。
 workHome: ''
 
+# workHomeMode is used to set the file mode bits for the workHome directory.
+# The default is 0755.
+workHomeMode: 0755
+
 # 服务的日志目录。
 # Linux 上默认目录 /var/log/dragonfly。
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/logs。
@@ -30,6 +34,10 @@ logDir: ''
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/cache。
 cacheDir: ''
 
+# cacheDirMode is used to set the file mode bits for the cacheDir directory.
+# The default is 0755.
+cacheDirMode: 0755
+
 # 服务的插件目录。
 # Linux 上默认目录 /usr/local/dragonfly/plugins。
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/plugins。
@@ -39,6 +47,10 @@ pluginDir: ''
 # Linux 上默认目录为 /var/lib/dragonfly。
 # macOS(仅开发、测试), 默认目录是 /Users/$USER/.dragonfly/data/。
 dataDir: ''
+
+# dataDirMode is used to set the file mode bits for the dataDir directory.
+# The default is 0755.
+dataDirMode: 0755
 
 # 当 daemon 退出是, 是否保存缓存数据。
 # 保留缓存数据在升级 daemon 的时候比较有用。

--- a/versioned_docs/version-v2.1.0/reference/configuration/dfdaemon.md
+++ b/versioned_docs/version-v2.1.0/reference/configuration/dfdaemon.md
@@ -21,6 +21,10 @@ gcInterval: 1m0s
 # In macos(just for testing), default value is /Users/$USER/.dragonfly.
 workHome: ''
 
+# workHomeMode is used to set the file mode bits for the workHome directory.
+# The default is 0755.
+workHomeMode: 0755
+
 # logDir is the log directory.
 # In linux, default value is /var/log/dragonfly.
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
@@ -31,6 +35,10 @@ logDir: ''
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/cache.
 cacheDir: ''
 
+# cacheDirMode is used to set the file mode bits for the cacheDir directory.
+# The default is 0755.
+cacheDirMode: 0755
+
 # pluginDir is the plugin directory.
 # In linux, default value is /usr/local/dragonfly/plugins.
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
@@ -40,6 +48,10 @@ pluginDir: ''
 # In linux, default value is /var/lib/dragonfly.
 # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
 dataDir: ''
+
+# dataDirMode is used to set the file mode bits for the dataDir directory.
+# The default is 0755.
+dataDirMode: 0755
 
 # When daemon exit, keep peer task data or not.
 # it is usefully when upgrade daemon service, all local cache will be saved


### PR DESCRIPTION
Add documentation for new config added in https://github.com/dragonflyoss/Dragonfly2/pull/2340 ( feat: enable configuration of some directory modes for dfdaemon)

## Description

Needed to document three new configuration parameters for dfdaemon: workHomeMode, cacheDirMode, and dataDirMode

## Related Issue

https://github.com/dragonflyoss/d7y.io/issues/70

## Motivation and Context

Missing docs
