### PR TITLE
docs: add prefetchRateLimit to dfdaemon configuration documentation

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -206,6 +206,9 @@ proxy:
   # If the value is "true", the range request will prefetch the entire file.
   # If the value is "false", the range request will fetch the range content.
   prefetch: false
+  # prefetchRateLimit is the rate limit of the prefetch speed in KiB/MiB/GiB per second, default is 2GiB/s.
+  # The prefetch request has lower priority so limit the rate to avoid occupying the bandwidth impact other download tasks.
+  prefetchRateLimit: 2GiB
   # readBufferSize is the buffer size for reading piece from disk, default is 32KB.
   readBufferSize: 32768
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
