### PR TITLE
docs: change lfu size of the manager cache

### DIFF
--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -135,7 +135,7 @@ cache:
   # Local cache configure.
   local:
     # LFU cache size.
-    size: 200000
+    size: 50000
     # Cache ttl configure.
     ttl: 3m
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a change to the `docs/reference/configuration/manager.md` file. The change modifies the local cache size configuration.

* [`docs/reference/configuration/manager.md`](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cL138-R138): Reduced the local cache size from 200000 to 50000.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
