### PR TITLE
docs(reference/configuration/client): add request rate limit for client's grpc server

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -37,6 +37,8 @@ download:
   server:
     # socketPath is the unix socket path for dfdaemon GRPC service.
     socketPath: /var/run/dragonfly/dfdaemon.sock
+    # request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s.
+    requestRateLimit: 4000
   # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
   rateLimit: 10GiB
   # pieceTimeout is the timeout for downloading a piece from source.
@@ -56,7 +58,8 @@ upload:
   # cert: /etc/ssl/certs/server.crt
   # # GRPC server key file path for mTLS.
   # key: /etc/ssl/private/server.pem
-  #
+    # request_rate_limit is the rate limit of the upload request in the upload grpc server, default is 4000 req/s.
+    requestRateLimit: 4000
 # # Client configuration for remote peer's upload server.
 # client:
 #   # CA certificate file path for mTLS.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `dfdaemon` configuration documentation to add rate limit settings for both download and upload requests.

Configuration documentation updates:

* [`docs/reference/configuration/client/dfdaemon.md`](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bR40-R41): Added `requestRateLimit` setting to specify the rate limit of the download request in the download grpc server, with a default value of 4000 req/s.
* [`docs/reference/configuration/client/dfdaemon.md`](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL59-R62): Added `requestRateLimit` setting to specify the rate limit of the upload request in the upload grpc server, with a default value of 4000 req/s.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3811
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
