### PR TITLE
docs: add preheat by Self-Signed Certificate

### DIFF
--- a/docs/operations/best-practices/security.md
+++ b/docs/operations/best-practices/security.md
@@ -63,6 +63,28 @@ auth:
 
 <!-- markdownlint-restore -->
 
+## Job
+
+### Preheat with Self-Signed Certificate
+
+When preheating the image, dragonfly needs to call the container registry to get the image manifest.
+If container regsitry is configured with a self-signed certificate, then dragonfly must be configured
+with a self-signed certificate. Configure `manager.yaml`,
+the default path is `/etc/dragonfly/manager.yaml`, refer to
+[manager](../../reference/configuration/manager.md) config.
+
+```yaml
+# Job configuration.
+job:
+  # Preheat configuration.
+  preheat:
+    tls:
+      # insecureSkipVerify controls whether a client verifies the server's certificate chain and hostname.
+      insecureSkipVerify: false
+      # caCert is the CA certificate for preheat tls handshake, it can be path or PEM format string.
+      caCert: ca.crt
+```
+
 ## Peer's HTTP proxy
 
 Peer's HTTP proxy has several security options that you need to configure according to the following documentation.

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "version": "./scripts/version.sh"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.6.3",
-    "@docusaurus/plugin-content-blog": "^3.6.3",
-    "@docusaurus/plugin-content-docs": "^3.6.3",
-    "@docusaurus/preset-classic": "^3.6.3",
+    "@docusaurus/core": "^3.7.0",
+    "@docusaurus/plugin-content-blog": "^3.7.0",
+    "@docusaurus/plugin-content-docs": "^3.7.0",
+    "@docusaurus/preset-classic": "^3.7.0",
     "@mdx-js/react": "^3.1.0",
     "@types/react": "^19.0.2",
     "acorn": "^8.7.1",
@@ -28,7 +28,7 @@
     "lottie-react": "^2.3.1",
     "lottie-web": "^5.9.6",
     "prism-react-renderer": "^2.1.0",
-    "react": "^18.3.1",
+    "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-github-btn": "^1.2.1",
     "react-youtube": "^10.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes an addition to the `docs/operations/best-practices/security.md` file and upgrades docusaurus to 3.7.0.  The change introduces a new section on configuring a self-signed certificate for preheating images with Dragonfly.

* Added a new section titled "Preheat by Self-Signed Certificate" to the `security.md` file, providing instructions and a YAML configuration example for setting up a self-signed certificate in `manager.yaml` for Dragonfly.

* Upgraded docusaurus to 3.7.0 and React to 19.0.0 in the `package.json` file.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3811
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
