### PR TITLE
feat: optimize the default value of the config

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -39,8 +39,8 @@ download:
     socketPath: /var/run/dragonfly/dfdaemon.sock
     # request_rate_limit is the rate limit of the download request in the download grpc server, default is 4000 req/s.
     requestRateLimit: 4000
-  # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 50GiB/s.
+  rateLimit: 50GiB
   # pieceTimeout is the timeout for downloading a piece from source.
   pieceTimeout: 30s
   # concurrentPieceCount is the number of concurrent pieces to download.
@@ -70,8 +70,8 @@ upload:
 #   key: /etc/ssl/private/client.pem
   # disableShared indicates whether disable to share data for other peers.
   disableShared: false
-  # rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 50GiB/s.
+  rateLimit: 50GiB
 
 manager:
   # addr is manager address.
@@ -121,10 +121,10 @@ storage:
   dir: /var/lib/dragonfly/
   # keep indicates whether keep the task's metadata and content when the dfdaemon restarts.
   keep: true
-  # writeBufferSize is the buffer size for writing piece to disk, default is 128KB.
-  writeBufferSize: 131072
-  # readBufferSize is the buffer size for reading piece from disk, default is 128KB.
-  readBufferSize: 131072
+  # writeBufferSize is the buffer size for writing piece to disk, default is 4MiB.
+  writeBufferSize: 4194304
+  # readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
+  readBufferSize: 4194304
 
 gc:
   # interval is the interval to do gc.
@@ -209,11 +209,11 @@ proxy:
   # If the value is "true", the range request will prefetch the entire file.
   # If the value is "false", the range request will fetch the range content.
   prefetch: false
-  # prefetchRateLimit is the rate limit of the prefetch speed in KiB/MiB/GiB per second, default is 2GiB/s.
+  # prefetchRateLimit is the rate limit of the prefetch speed in KiB/MiB/GiB per second, default is 5GiB/s.
   # The prefetch request has lower priority so limit the rate to avoid occupying the bandwidth impact other download tasks.
-  prefetchRateLimit: 2GiB
-  # readBufferSize is the buffer size for reading piece from disk, default is 32KB.
-  readBufferSize: 32768
+  prefetchRateLimit: 5GiB
+  # readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
+  readBufferSize: 4194304
 
 metrics:
   server:

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -79,7 +79,7 @@ scheduler:
     peerGCInterval: 10s
     # peerTTL is the ttl of peer. If the peer has been downloaded by other peers,
     # then PeerTTL will be reset
-    peerTTL: 24h
+    peerTTL:48h
     # taskGCInterval is the interval of task gc. If all the peers have been reclaimed in the task,
     # then the task will also be reclaimed.
     taskGCInterval: 30m
@@ -156,16 +156,6 @@ job:
   schedulerWorkerNum: 500
   # Number of workers in local queue.
   localWorkerNum: 1000
-
-# Store task download information.
-storage:
-  # maxSize sets the maximum size in megabytes of storage file.
-  maxSize: 100
-  # maxBackups sets the maximum number of storage files to retain.
-  maxBackups: 10
-  # bufferSize sets the size of buffer container,
-  # if the buffer is full, write all the records in the buffer to the file.
-  bufferSize: 100
 
 # Enable prometheus metrics.
 metrics:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several updates to the configuration documentation for `dfdaemon` and `scheduler`. Key changes involve increasing rate limits, buffer sizes, and peer TTL.

### Configuration updates:

* `docs/reference/configuration/client/dfdaemon.md`: 
  - Increased the default rate limit for download speed from 10GiB/s to 50GiB/s.
  - Increased the default rate limit for upload speed from 10GiB/s to 50GiB/s.
  - Increased the buffer size for writing and reading pieces to/from disk from 128KB to 4MiB.
  - Increased the prefetch rate limit from 2GiB/s to 5GiB/s and the buffer size for reading pieces from disk to 4MiB.

* `docs/reference/configuration/scheduler.md`:
  - Extended the peer TTL from 24h to 48h.
  - Removed the storage section that set maximum size, backups, and buffer size for task download information storage.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
