### PR TITLE
docs: fix typo in scheduler configuration

### DIFF
--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -95,7 +95,7 @@ database:
   redis:
     # Redis addresses.
     addrs:
-      - redis-servive:6379
+      - redis-service:6379
     # Redis sentinel master name.
     masterName: ''
     # Redis username.

--- a/versioned_docs/version-v2.1.0/reference/configuration/scheduler.md
+++ b/versioned_docs/version-v2.1.0/reference/configuration/scheduler.md
@@ -86,7 +86,7 @@ database:
   redis:
     # Redis addresses.
     addrs:
-      - redis-servive:6379
+      - redis-service:6379
     # Redis sentinel master name.
     masterName: ''
     # Redis username.

--- a/versioned_docs/version-v2.1.x/reference/configuration/scheduler.md
+++ b/versioned_docs/version-v2.1.x/reference/configuration/scheduler.md
@@ -86,7 +86,7 @@ database:
   redis:
     # Redis addresses.
     addrs:
-      - redis-servive:6379
+      - redis-service:6379
     # Redis sentinel master name.
     masterName: ''
     # Redis username.

--- a/versioned_docs/version-v2.2.0/reference/configuration/scheduler.md
+++ b/versioned_docs/version-v2.2.0/reference/configuration/scheduler.md
@@ -95,7 +95,7 @@ database:
   redis:
     # Redis addresses.
     addrs:
-      - redis-servive:6379
+      - redis-service:6379
     # Redis sentinel master name.
     masterName: ''
     # Redis username.


### PR DESCRIPTION
`redis-servive` --> `redis-service`