### PR TITLE
docs: fix parsing error in scheduler configuration

### DIFF
--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -79,7 +79,7 @@ scheduler:
     peerGCInterval: 10s
     # peerTTL is the ttl of peer. If the peer has been downloaded by other peers,
     # then PeerTTL will be reset
-    peerTTL:48h
+    peerTTL: 48h
     # taskGCInterval is the interval of task gc. If all the peers have been reclaimed in the task,
     # then the task will also be reclaimed.
     taskGCInterval: 30m


### PR DESCRIPTION
Add the missing whitespace for scheduler config.

![image](https://github.com/user-attachments/assets/2cc4c8dc-5869-4d94-ad8a-d4f62cb475a5)

## Description

<img width="848" alt="{369F9C46-E0D5-480B-A8B8-CD801232FB8D}" src="https://github.com/user-attachments/assets/021f548d-dee7-40ab-9ce8-dd2728d309a6" />
