### PR TITLE
docs: add dfget download via UDS

### DIFF
--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -143,13 +143,70 @@ Options:
 
 ## Example {#example}
 
-### Download with HTTP protocol {#downlad-with-http}
+### Download in Container {#download-in-container}
+
+#### Install Dragonfly in the Kubernetes cluster
+
+Deploy Dragonfly components across your cluster:
+
+```shell
+helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+helm install --create-namespace -n dragonfly-system dragonfly dragonfly/dragonfly
+```
+
+For detailed installation options, refer to [Helm Charts Installation Guide](../../../getting-started/installation/helm-charts.md).
+
+#### Mount the Unix Domain Socket of dfdaemon to the Pod
+
+Add the following configuration to your Pod definition to mount the Dragonfly daemon's Unix Domain Socket,
+then the container can use the same dfdaemon to download files in the node.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runtime
+spec:
+  containers:
+    - name: runtime
+      image: your-image:tag
+      volumeMounts:
+        - mountPath: /var/run/dragonfly/dfdaemon.sock
+          name: dfdaemon-socket
+  volumes:
+    - name: dfdaemon-socket
+      hostPath:
+        path: /var/run/dragonfly/dfdaemon.sock
+        type: Socket
+```
+
+#### Install Dfget in the Container Image
+
+Install Dfget in the Container Image, refer to [Install Client using RPM](../../../getting-started/installation/binaries.md#install-client-using-rpm-install-client-using-rpm)
+or [Install Client using DEB](../../../getting-started/installation/binaries.md#install-client-using-deb-install-client-using-deb).
+
+#### Download via UDS(unix domain socket) of dfdaemon in the node
+
+Once set up, use the dfget command with the `--transfer-from-dfdaemon` flag to download files:
+
+```shell
+dfget --transfer-from-dfdaemon https://<host>:<port>/<path> -O /tmp/file.txt
+```
+
+`--transfer-from-dfdaemon` specify whether to transfer the content of downloading file from dfdaemon's unix domain socket. If it is `true`,
+dfget will call dfdaemon to download the file, and dfdaemon will return the content of downloading file to
+dfget via unix domain socket, and dfget will copy the content to the output path. If it is `false`, dfdaemon will
+download the file and hardlink or copy the file to the output path.
+
+### Dwonload with different protocols {#download-with-different-protocols}
+
+#### Download with HTTP protocol
 
 ```shell
 dfget https://<host>:<port>/<path> -O /tmp/file.txt
 ```
 
-### Download with S3 protocol {#downlad-with-s3}
+#### Download with S3 protocol
 
 ```shell
 # Download a file.
@@ -159,7 +216,7 @@ dfget s3://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key_
 dfget s3://<bucket/<path>/ -O /tmp/path/ --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret>
 ```
 
-### Download with GCS protocol {#downlad-with-gcs}
+#### Download with GCS protocol
 
 ```shell
 # Download a file.
@@ -169,7 +226,7 @@ dfget gs://<bucket>/<path> -O /tmp/file.txt --storage-credential-path=<credentia
 dfget gs://<bucket>/<path>/ -O /tmp/path/ --storage-credential-path=<credential_path>
 ```
 
-### Download with ABS protocol {#downlad-with-abs}
+#### Download with ABS protocol
 
 ```shell
 # Download a file.
@@ -179,7 +236,7 @@ dfget abs://<container>/<path> -O /tmp/file.txt --storage-access-key-id=<account
 dfget abs://<container>/<path>/ -O /tmp/path/ --storage-access-key-id=<account_name> --storage-access-key-secret=<account_key>
 ```
 
-### Download with OSS protocol {#downlad-with-oss}
+#### Download with OSS protocol
 
 ```shell
 # Download a file.
@@ -189,7 +246,7 @@ dfget oss://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key
 dfget oss://<bucket>/<path>/ -O /tmp/path/ --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
 ```
 
-### Download with OBS protocol {#downlad-with-obs}
+#### Download with OBS protocol
 
 ```shell
 # Download a file.
@@ -199,7 +256,7 @@ dfget obs://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key
 dfget obs://<bucket>/<path>/ -O /tmp/path/ --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
 ```
 
-### Download with COS protocol {#downlad-with-cos}
+#### Download with COS protocol
 
 > Note: The endpoint does not require `BucketName-APPID`, just --storage-endpoint=cos.region.myqcloud.com.
 
@@ -211,7 +268,7 @@ dfget cos://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key
 dfget cos://<bucket>/<path>/ -O /tmp/path/ --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
 ```
 
-### Download with HDFS protocol {#downlad-with-hdfs}
+#### Download with HDFS protocol
 
 ```shell
 dfget hdfs://<path>/file.txt -O /tmp/file.txt  --hdfs-delegation-token <hadoop_delegation_token>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `docs/reference/commands/client/dfget.md` file to improve the documentation for downloading files using different protocols and to add new instructions for downloading within a container.

### Documentation improvements and new instructions:

* Added detailed instructions for installing Dragonfly in a Kubernetes cluster and configuring a Pod to use the Dragonfly daemon's Unix Domain Socket for downloading files.
* Introduced a new section on how to install Dfget in the container image and use it to download files via the Unix Domain Socket of dfdaemon.
* Reorganized the download protocol sections by changing the headings from "###" to "####" for better hierarchy and readability. [[1]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L162-R219) [[2]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L172-R229) [[3]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L182-R239) [[4]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L192-R249) [[5]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L202-R259) [[6]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L214-R271)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
