### PR TITLE
docs(reference/commands/client): mount host's socket dir to pod

### DIFF
--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -171,13 +171,13 @@ spec:
     - name: runtime
       image: your-image:tag
       volumeMounts:
-        - mountPath: /var/run/dragonfly/dfdaemon.sock
-          name: dfdaemon-socket
+        - mountPath: /var/run/dragonfly
+          name: dfdaemon-socket-dir
   volumes:
-    - name: dfdaemon-socket
+    - name: dfdaemon-socket-dir
       hostPath:
-        path: /var/run/dragonfly/dfdaemon.sock
-        type: Socket
+        path: /var/run/dragonfly
+        type: DirectoryOrCreate
 ```
 
 #### Install Dfget in the Container Image


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a change to the `docs/reference/commands/client/dfget.md` file. The change modifies the volume mount configuration for the `dfdaemon` socket to use a directory instead of a socket.

Configuration changes:

* [`docs/reference/commands/client/dfget.md`](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3L174-R180): Updated the volume mount path and type from `/var/run/dragonfly/dfdaemon.sock` to `/var/run/dragonfly` and from `Socket` to `Directory`.
<!--- Describe your changes in detail -->

## Related Issue
Fixed https://github.com/dragonflyoss/client/issues/1058.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
