### PR TITLE
Update configure-development-nvironment.md

### DIFF
--- a/docs/development-guide/configure-development-nvironment.md
+++ b/docs/development-guide/configure-development-nvironment.md
@@ -13,7 +13,7 @@ This document describes how to configure a local development environment for Dra
 | Name     | Version                      | Document                                                                     |
 | -------- | ---------------------------- | ---------------------------------------------------------------------------- |
 | Git      | 1.9.1+                       | [git-scm](https://git-scm.com/)                                              |
-| Golang   | 1.16.x                       | [go.dev](https://go.dev/)                                                    |
+| Golang   | 1.23.x                       | [go.dev](https://go.dev/)                                                    |
 | Rust     | 1.6+                         | [rustup.rs](https://rustup.rs/)                                              |
 | Database | Mysql 5.6+ OR PostgreSQL 12+ | [mysql](https://www.mysql.com/) OR [postgresql](https://www.postgresql.org/) |
 | Redis    | 3.0+                         | [redis.io](https://redis.io/)                                                |


### PR DESCRIPTION

## Description
Update the  dependency version  of golang
更新go语言的依赖版本。
<!--- Describe your changes in detail -->

## Motivation and Context
This change caters to the main repositry (https://github.com/dragonflyoss/dragonfly)'s requirement of golang's version.
这个改变迎合了主仓库对于golang版本的需求。

in go.mod :
`module d7y.io/dragonfly/v2
go 1.23.8`

But the version before the modification requires 1.16.x.
但是在修改前文档显示的版本是1.16.x。

And I tried to execute  `go run cmd/scheduler/main.go --config /etc/dragonfly/scheduler.yaml --verbose --console` ,However the error message told me that pay attention to 'go 1.23.8' in dragonfly/go.mod 
并且我尝试去执行 `go run cmd/scheduler/main.go --config /etc/dragonfly/scheduler.yaml --verbose --console`, 然而错误信息体现我去关心在dragonfly/go.mod 中的'go 1.23.8'。
<!--- Why is this change required? What problem does it solve? -->
