### PR TITLE
chore: prerequisites  bump golang version to 1.23.8+

### DIFF
--- a/docs/development-guide/configure-development-nvironment.md
+++ b/docs/development-guide/configure-development-nvironment.md
@@ -13,7 +13,7 @@ This document describes how to configure a local development environment for Dra
 | Name     | Version                      | Document                                                                     |
 | -------- | ---------------------------- | ---------------------------------------------------------------------------- |
 | Git      | 1.9.1+                       | [git-scm](https://git-scm.com/)                                              |
-| Golang   | 1.23.x                       | [go.dev](https://go.dev/)                                                    |
+| Golang   | 1.23.8+                       | [go.dev](https://go.dev/)                                                    |
 | Rust     | 1.6+                         | [rustup.rs](https://rustup.rs/)                                              |
 | Database | Mysql 5.6+ OR PostgreSQL 12+ | [mysql](https://www.mysql.com/) OR [postgresql](https://www.postgresql.org/) |
 | Redis    | 3.0+                         | [redis.io](https://redis.io/)                                                |

--- a/docs/development-guide/running-tests.md
+++ b/docs/development-guide/running-tests.md
@@ -12,7 +12,7 @@ This document describes how to run unit tests and E2E tests.
 
 | Name   | Version | Document                        |
 | ------ | ------- | ------------------------------- |
-| Golang | 1.16.x  | [go.dev](https://go.dev/)       |
+| Golang | 1.23.8+ | [go.dev](https://go.dev/)       |
 | Rust   | 1.6+    | [rustup.rs](https://rustup.rs/) |
 
 <!-- markdownlint-restore -->

--- a/docs/getting-started/installation/binaries.md
+++ b/docs/getting-started/installation/binaries.md
@@ -13,7 +13,7 @@ This guide shows how to install the Dragonfly. Dragonfly can be installed either
 | Name     | Version                      | Document                                                                     |
 | -------- | ---------------------------- | ---------------------------------------------------------------------------- |
 | Git      | 1.9.1+                       | [git-scm](https://git-scm.com/)                                              |
-| Golang   | 1.16.x                       | [go.dev](https://go.dev/)                                                    |
+| Golang   | 1.23.8+                      | [go.dev](https://go.dev/)                                                    |
 | Rust     | 1.6+                         | [rustup.rs](https://rustup.rs/)                                              |
 | Database | Mysql 5.6+ OR PostgreSQL 12+ | [mysql](https://www.mysql.com/) OR [postgresql](https://www.postgresql.org/) |
 | Redis    | 3.0+                         | [redis.io](https://redis.io/)                                                |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This pull request bumps the prerequisite golang version to 1.23.8+.

refer to: https://github.com/dragonflyoss/dragonfly/pull/3960
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
