### PR TITLE
docs: remove job gc configuration

### DIFF
--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -149,12 +149,6 @@ job:
     capacity: 5
     # quantum is the number of tokens taken from the bucket for each request.
     quantum: 5
-  # gc configuration.
-  gc:
-    # Interval is the interval for garbage collection.
-    interval: 3h
-    # TTL is the time to live for the job.
-    ttl: 6h
   # Sync peers configuration.
   syncPeers:
     # Interval is the interval for syncing all peers information from the scheduler and


### PR DESCRIPTION
This pull request removes the garbage collection (`gc`) configuration section from the `manager` configuration documentation. The `gc` section, which included settings for `interval` and `ttl`, is no longer present.

Key change:

* [`docs/reference/configuration/manager.md`](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cL152-L157): Removed the `gc` configuration section, which included the `interval` (garbage collection interval) and `ttl` (time-to-live for jobs) settings.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
