### PR TITLE
docs: update scheduleTimeout and pieceTimeout for dfdaemon config

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -42,7 +42,7 @@ download:
   # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 50GiB/s.
   rateLimit: 50GiB
   # pieceTimeout is the timeout for downloading a piece from source.
-  pieceTimeout: 30s
+  pieceTimeout: 60s
   # concurrentPieceCount is the number of concurrent pieces to download.
   concurrentPieceCount: 10
 
@@ -88,9 +88,36 @@ scheduler:
   # Announcer will provide the scheduler with peer information for scheduling,
   # peer information includes cpu, memory, etc.
   announceInterval: 1m
-  # scheduleTimeout is the timeout for scheduling. If the scheduling timesout, dfdaemon will back-to-source
-  # download if enableBackToSource is true, otherwise dfdaemon will return download failed.
-  scheduleTimeout: 30s
+  # schedule_timeout is timeout for the scheduler to respond to a scheduling request from dfdaemon, default is 3 hours.
+  #
+  # If the scheduler's response time for a scheduling decision exceeds this timeout,
+  # dfdaemon will encounter a `TokioStreamElapsed(Elapsed(()))` error.
+  #
+  # Behavior upon timeout:
+  #   - If `enable_back_to_source` is `true`, dfdaemon will attempt to download directly
+  #     from the source.
+  #   - Otherwise (if `enable_back_to_source` is `false`), dfdaemon will report a download failure.
+  #
+  # **Important Considerations Regarding Timeout Triggers**:
+  # This timeout isn't solely for the scheduler's direct response. It can also be triggered
+  # if the overall duration of the client's interaction with the scheduler for a task
+  # (e.g., client downloading initial pieces and reporting their status back to the scheduler)
+  # exceeds `schedule_timeout`. During such client-side processing and reporting,
+  # the scheduler might be awaiting these updates before sending its comprehensive
+  # scheduling response, and this entire period is subject to the `schedule_timeout`.
+  #
+  # **Configuration Guidance**:
+  # To prevent premature timeouts, `schedule_timeout` should be configured to a value
+  # greater than the maximum expected time for the *entire scheduling interaction*.
+  # This includes:
+  #   1. The scheduler's own processing and response time.
+  #   2. The time taken by the client to download any initial pieces and download all pieces finished,
+  #      as this communication is part of the scheduling phase.
+  #
+  # Setting this value too low can lead to `TokioStreamElapsed` errors even if the
+  # network and scheduler are functioning correctly but the combined interaction time
+  # is longer than the configured timeout.
+  scheduleTimeout: 3h
   # maxScheduleCount is the max count of schedule.
   maxScheduleCount: 5
   # enableBackToSource indicates whether enable back-to-source download, when the scheduling failed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in
This pull request updates the configuration documentation for `dfdaemon` to adjust timeouts and improve clarity. The most significant changes involve increasing the default values for `pieceTimeout` and `scheduleTimeout`, along with detailed explanations for the `scheduleTimeout` behavior and configuration.

### Timeout Configuration Updates:
* **`pieceTimeout`**: Increased the timeout for downloading a piece from the source from `30s` to `60s` to provide more time for each piece download. (`[docs/reference/configuration/client/dfdaemon.mdL45-R45](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL45-R45)`)
* **`scheduleTimeout`**: Increased the scheduler timeout from `30s` to `3h` and added a comprehensive explanation of its behavior, including how it impacts interactions with the scheduler and guidance on setting an appropriate value to avoid premature timeouts. (`[docs/reference/configuration/client/dfdaemon.mdL91-R120](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL91-R120)`) detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
