### PR TITLE
docs: rename verbose to console in client command

### DIFF
--- a/docs/getting-started/installation/helm-charts.md
+++ b/docs/getting-started/installation/helm-charts.md
@@ -76,9 +76,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -86,9 +83,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -96,8 +90,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -105,8 +97,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:

--- a/docs/getting-started/quick-start/kubernetes.md
+++ b/docs/getting-started/quick-start/kubernetes.md
@@ -76,9 +76,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -86,9 +83,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -96,8 +90,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -105,8 +97,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:

--- a/docs/getting-started/quick-start/multi-cluster-kubernetes.md
+++ b/docs/getting-started/quick-start/multi-cluster-kubernetes.md
@@ -104,9 +104,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   nodeSelector:
@@ -116,9 +113,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   nodeSelector:
@@ -128,8 +122,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   nodeSelector:
@@ -139,8 +131,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
   dfinit:
     enable: true
@@ -329,8 +319,6 @@ scheduler:
   metrics:
     enable: true
   config:
-    verbose: true
-    pprofPort: 18066
     manager:
       addr: dragonfly-manager.cluster-a.svc.cluster.local:65003
       schedulerClusterID: 2
@@ -344,7 +332,6 @@ seedClient:
   metrics:
     enable: true
   config:
-    verbose: true
     manager:
       addr: http://dragonfly-manager.cluster-a.svc.cluster.local:65003
     seedPeer:
@@ -358,8 +345,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:

--- a/docs/operations/best-practices/observability/monitoring.md
+++ b/docs/operations/best-practices/observability/monitoring.md
@@ -134,9 +134,6 @@ manager:
       enable: true
     prometheusRule:
       enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -149,9 +146,6 @@ scheduler:
       enable: true
     prometheusRule:
       enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -164,7 +158,6 @@ seedClient:
     prometheusRule:
       enable: true
   config:
-    verbose: true
     log:
       level: info
     proxy:
@@ -201,9 +194,6 @@ client:
               serverAddr: https://ghcr.io
               capabilities: ['pull', 'resolve']
   config:
-    verbose: true
-    log:
-      level: info
     proxy:
       prefetch: true
       registryMirror:

--- a/docs/operations/best-practices/observability/tracing.md
+++ b/docs/operations/best-practices/observability/tracing.md
@@ -27,8 +27,8 @@ docker run --rm --name jaeger \
 
 ```yaml
 tracing:
-#   # addr is the address to report tracing log. 6831 is default udp port.
-  addr: {endpoint}:6831
+#   # addr is the address to report tracing log. 4317 is default grpc port.
+  addr: {endpoint}:4317
 ```
 
 #### 2. Make a download request and check the tracing UI

--- a/docs/operations/integrations/container-runtime/containerd.md
+++ b/docs/operations/integrations/container-runtime/containerd.md
@@ -75,9 +75,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -85,9 +82,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -95,8 +89,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -104,8 +96,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:
@@ -222,9 +212,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -232,9 +219,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -242,8 +226,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -251,8 +233,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:
@@ -329,9 +309,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -339,9 +316,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -349,8 +323,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -358,8 +330,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:
@@ -481,7 +451,6 @@ manager:
   metrics:
     enable: true
   config:
-    verbose: true
     pprofPort: 18066
     job:
       preheat:
@@ -502,9 +471,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -513,7 +479,6 @@ seedClient:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       registryMirror:
         addr: https://yourdomain.com
@@ -533,7 +498,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       registryMirror:
         addr: https://yourdomain.com

--- a/docs/operations/integrations/container-runtime/cri-o.md
+++ b/docs/operations/integrations/container-runtime/cri-o.md
@@ -64,9 +64,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -74,9 +71,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -84,8 +78,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -93,8 +85,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:
@@ -284,8 +274,6 @@ manager:
   metrics:
     enable: true
   config:
-    verbose: true
-    pprofPort: 18066
     job:
       preheat:
         tls:
@@ -305,9 +293,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -316,7 +301,6 @@ seedClient:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       registryMirror:
         addr: https://yourdomain.com
@@ -336,7 +320,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       registryMirror:
         addr: https://yourdomain.com

--- a/docs/operations/integrations/container-runtime/nydus.md
+++ b/docs/operations/integrations/container-runtime/nydus.md
@@ -90,9 +90,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -100,9 +97,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -111,7 +105,6 @@ seedClient:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       prefetch: true
 
@@ -123,7 +116,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       prefetch: true
       server:

--- a/docs/operations/integrations/container-runtime/podman.md
+++ b/docs/operations/integrations/container-runtime/podman.md
@@ -64,9 +64,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -74,9 +71,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -84,8 +78,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -93,8 +85,6 @@ client:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
   dfinit:
     enable: true
     image:
@@ -284,8 +274,6 @@ manager:
   metrics:
     enable: true
   config:
-    verbose: true
-    pprofPort: 18066
     job:
       preheat:
         tls:
@@ -305,9 +293,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -316,7 +301,6 @@ seedClient:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       registryMirror:
         addr: https://yourdomain.com
@@ -336,7 +320,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       registryMirror:
         addr: https://yourdomain.com

--- a/docs/operations/integrations/container-runtime/stargz.md
+++ b/docs/operations/integrations/container-runtime/stargz.md
@@ -84,9 +84,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -94,9 +91,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -105,7 +99,6 @@ seedClient:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       prefetch: true
 
@@ -117,7 +110,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       prefetch: true
       server:

--- a/docs/operations/integrations/git-lfs.md
+++ b/docs/operations/integrations/git-lfs.md
@@ -163,9 +163,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -173,9 +170,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -183,8 +177,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -194,7 +186,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       server:
         port: 4001

--- a/docs/operations/integrations/hugging-face.md
+++ b/docs/operations/integrations/hugging-face.md
@@ -91,9 +91,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -101,9 +98,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -111,8 +105,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -122,7 +114,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       server:
         port: 4001

--- a/docs/operations/integrations/pip.md
+++ b/docs/operations/integrations/pip.md
@@ -87,9 +87,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -97,9 +94,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -107,8 +101,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -118,7 +110,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       server:
         port: 4001

--- a/docs/operations/integrations/torchserve.md
+++ b/docs/operations/integrations/torchserve.md
@@ -106,9 +106,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -116,9 +113,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -126,8 +120,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -136,7 +128,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       server:
         port: 4001

--- a/docs/operations/integrations/triton-server.md
+++ b/docs/operations/integrations/triton-server.md
@@ -91,9 +91,6 @@ manager:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 scheduler:
   image:
@@ -101,9 +98,6 @@ scheduler:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
-    pprofPort: 18066
 
 seedClient:
   image:
@@ -111,8 +105,6 @@ seedClient:
     tag: latest
   metrics:
     enable: true
-  config:
-    verbose: true
 
 client:
   image:
@@ -121,7 +113,6 @@ client:
   metrics:
     enable: true
   config:
-    verbose: true
     proxy:
       server:
         port: 4001

--- a/docs/reference/commands/client/dfcache.md
+++ b/docs/reference/commands/client/dfcache.md
@@ -116,7 +116,7 @@ Options:
 
           [default: 6]
 
-      --verbose
+      --console
           Specify whether to print log
 
   -h, --help
@@ -183,7 +183,7 @@ Options:
 
           [default: 6]
 
-      --verbose
+      --console
           Specify whether to print log
 
   -h, --help
@@ -226,7 +226,7 @@ Options:
 
           [default: 6]
 
-      --verbose
+      --console
           Specify whether to print log
 
   -h, --help
@@ -327,6 +327,6 @@ dfcache stat <ID>
 ## Log
 
 ```text
-1. set option --verbose if you want to print logs to Terminal
+1. set option --console if you want to print logs to Terminal
 2. log path: /var/log/dragonfly/dfcache/
 ```

--- a/docs/reference/commands/client/dfdaemon.md
+++ b/docs/reference/commands/client/dfdaemon.md
@@ -38,7 +38,7 @@ Meanwhile, it will act as an uploader to support other peers to download pieces 
 
           [default: 24]
 
-      --verbose
+      --console
           Specify whether to print log
 
   -h, --help
@@ -62,7 +62,7 @@ Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`,
 refer to [Dfdaemon](../../configuration/client/dfdaemon.md).
 
 > Notice: set `proxy.rules.regex` to match the download path.
-If the regex matches, intercepts download traffic and forwards it to the P2P network.
+> If the regex matches, intercepts download traffic and forwards it to the P2P network.
 
 ```yaml
 proxy:
@@ -84,7 +84,7 @@ Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`,
 refer to [Dfdaemon](../../configuration/client/dfdaemon.md).
 
 > Notice: set `proxy.rules.regex` to match the download path.
-If the regex matches, intercepts download traffic and forwards it to the P2P network.
+> If the regex matches, intercepts download traffic and forwards it to the P2P network.
 
 ```yaml
 proxy:
@@ -128,7 +128,7 @@ Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`,
 refer to [Dfdaemon](../../configuration/client/dfdaemon.md).
 
 > Notice: set `proxy.rules.regex` to match the download path.
-If the regex matches, intercepts download traffic and forwards it to the P2P network.
+> If the regex matches, intercepts download traffic and forwards it to the P2P network.
 
 ```yaml
 proxy:
@@ -149,6 +149,6 @@ curl -v -x 127.0.0.1:4001 https://example.com/file.txt --output /tmp/file.txt
 ## Log {#log}
 
 ```text
-1. set option --verbose if you want to print logs to Terminal
+1. set option --console if you want to print logs to Terminal
 2. log path: /var/log/dragonfly/dfdaemon/
 ```

--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -171,7 +171,7 @@ Options:
 
           [default: 6]
 
-      --verbose
+      --console
           Specify whether to print log
 
   -V, --version
@@ -319,6 +319,6 @@ dfget hdfs://<path>/file.txt -O /tmp/file.txt  --hdfs-delegation-token <hadoop_d
 ## Log {#log}
 
 ```text
-1. set option --verbose if you want to print logs to Terminal
+1. set option --console if you want to print logs to Terminal
 2. log path: /var/log/dragonfly/dfget/
 ```

--- a/docs/reference/commands/manager.md
+++ b/docs/reference/commands/manager.md
@@ -35,9 +35,6 @@ version     show version
     --config string         the path of configuration file with yaml extension name, default is /etc/dragonfly/manager.yaml, it can also be set by env var: MANAGER_CONFIG
     --console               whether logger output records to the stdout
 -h, --help                  help for manager
-    --jaeger string         jaeger endpoint url, like: http://localhost:14250/api/traces
-    --pprof-port int        listen port for pprof, 0 represents random port (default -1)
-    --service-name string   name of the service for tracer (default "dragonfly-manager")
     --verbose               whether logger use debug level
 ```
 

--- a/docs/reference/commands/scheduler.md
+++ b/docs/reference/commands/scheduler.md
@@ -35,9 +35,6 @@ version     show version
       --config string         the path of configuration file with yaml extension name, default is /etc/dragonfly/scheduler.yaml, it can also be set by env var: SCHEDULER_CONFIG
       --console               whether logger output records to the stdout
   -h, --help                  help for scheduler
-      --jaeger string         jaeger endpoint url, like: http://localhost:14250/api/traces
-      --pprof-port int        listen port for pprof, 0 represents random port (default -1)
-      --service-name string   name of the service for tracer (default "dragonfly-scheduler")
       --verbose               whether logger use debug level
 ```
 

--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -9,8 +9,8 @@ slug: /reference/configuration/client/dfdaemon/
 Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`.
 
 ```yaml
-# verbose prints log to stdout.
-verbose: true
+# console prints log to stdout.
+console: true
 
 log:
   # Specify the logging level [trace, debug, info, warn, error]

--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -190,6 +190,7 @@ verbose: true
 # default is -1. If it is 0, pprof will use a random port.
 pprof-port: -1
 
-# Jaeger endpoint url, like: http://jaeger.dragonfly.svc:14268/api/traces.
-jaeger: ''
+tracing:
+  # Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
+  addr: ''
 ```

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -180,6 +180,7 @@ verbose: true
 # default is -1. If it is 0, pprof will use a random port.
 pprof-port: -1
 
-# Jaeger endpoint url, like: http://jaeger.dragonfly.svc:14268/api/traces.
-jaeger: ''
+tracing:
+  # Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
+  addr: ''
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request removes redundant configuration options (`verbose` and `pprofPort`) across multiple documentation files for various integrations and setups. These changes simplify the configuration examples and ensure consistency across the documentation.

### Removal of redundant configuration options:

* **General configuration cleanup across documentation:**
  - Removed `verbose` and `pprofPort` settings from `manager`, `scheduler`, `seedClient`, and `client` sections in multiple files, including `helm-charts.md`, `kubernetes.md`, and `multi-cluster-kubernetes.md`. [[1]](diffhunk://#diff-e276711ab80bbb38742165eb1a848611aef9f017f5fd253178e29258b3788a12L79-L109) [[2]](diffhunk://#diff-5862e4531d54e3a6eac3189393c5ecf5af708815a4718778fdb6549500696bc8L79-L109) [[3]](diffhunk://#diff-69ac41ab62e02cf7f6703e044adde9ee08ddbaf0174fb8ca0fdc373ddc553129L107-L109) [[4]](diffhunk://#diff-69ac41ab62e02cf7f6703e044adde9ee08ddbaf0174fb8ca0fdc373ddc553129L119-L121) [[5]](diffhunk://#diff-69ac41ab62e02cf7f6703e044adde9ee08ddbaf0174fb8ca0fdc373ddc553129L131-L132) [[6]](diffhunk://#diff-69ac41ab62e02cf7f6703e044adde9ee08ddbaf0174fb8ca0fdc373ddc553129L142-L143)

* **Specific integrations cleanup:**
  - Removed `verbose` and `pprofPort` settings from integration-specific documentation files such as `containerd.md`, `cri-o.md`, `nydus.md`, `podman.md`, `stargz.md`, and `git-lfs.md`. [[1]](diffhunk://#diff-3c61d407e8f02a437315353e614cd3b6189c0c1b648cc990e48e69a1b2322722L78-L108) [[2]](diffhunk://#diff-0f6e0f7ec9955f0aebeaacb69b23bc75eaef71e95c3b527287f993c519e4bfdcL67-L97) [[3]](diffhunk://#diff-793f0683d0c0edb0c01d14af3038e0e973e80d837ffce8e2e5997f7fbbf999deL93-L105) [[4]](diffhunk://#diff-1da73c89b980b5145e11c3a492c410ac51f17a58a3b845f6c0f4a000581dae4eL67-L97) [[5]](diffhunk://#diff-aab629b96fe733c22f5444a2516443058ab694bc160a9b8230c8706b0f0ec529L87-L99) [[6]](diffhunk://#diff-282936d02ede2094ac16f29c7253bcbc1c89ecdfee8506f47c1f53a05b4dc18aL166-L187)

### Updates to tracing configuration:

* **Tracing configuration adjustment:**
  - Updated the default port for tracing logs from UDP (`6831`) to gRPC (`4317`) in `tracing.md`. This reflects a shift to a more modern protocol for tracing.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
