### PR TITLE
docs: add headers for tracing config

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -252,4 +252,6 @@ metrics:
 # tracing:
 # # addr is the address to report tracing log.
 # addr: ""
+# # headers is the grpc's headers to send with tracing log.
+# headers: {}
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a small addition to the `metrics:` section in the `dfdaemon.md` documentation file. The change introduces a new configuration option, `headers`, which allows specifying gRPC headers to send with tracing logs.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
