### PR TITLE
docs: add distThreshold for client config

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -159,6 +159,18 @@ gc:
   policy:
     # taskTTL is the ttl of the task.
     taskTTL: 21600s
+    # # distThreshold optionally defines a specific disk capacity to be used as the base for
+    # # calculating GC trigger points with `distHighThresholdPercent` and `distLowThresholdPercent`.
+    # #
+    # # - If a value is provided (e.g., "500GB"), the percentage-based thresholds (`distHighThresholdPercent`,
+    # #   `distLowThresholdPercent`) are applied relative to this specified capacity.
+    # # - If not provided or set to 0 (the default behavior), these percentage-based thresholds are applied
+    # #   relative to the total actual disk space.
+    # #
+    # # This allows dfdaemon to effectively manage a logical portion of the disk for its cache,
+    # # rather than always considering the entire disk volume.
+    #
+    # distThreshold: 10TiB
     # distHighThresholdPercent is the high threshold percent of the disk usage.
     # If the disk usage is greater than the threshold, dfdaemon will do gc.
     distHighThresholdPercent: 80


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `dfdaemon` configuration documentation to include a new optional parameter, `distThreshold`, which provides more flexibility in managing disk capacity for cache purposes.

Documentation updates:

* [`docs/reference/configuration/client/dfdaemon.md`](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bR162-R173): Added detailed comments explaining the new `distThreshold` parameter. This parameter allows users to define a specific disk capacity for calculating GC trigger points, enabling dfdaemon to manage a logical portion of the disk rather than the entire disk volume.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/client/issues/1184
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
