### PR TITLE
docs: change config of the gc in scheduler

### DIFF
--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -76,15 +76,15 @@ scheduler:
     # pieceDownloadTimeout is the timeout of downloading piece.
     pieceDownloadTimeout: 30m
     # peerGCInterval is the interval of peer gc.
-    peerGCInterval: 10s
+    peerGCInterval: 5m
     # peerTTL is the ttl of peer. If the peer has been downloaded by other peers,
     # then PeerTTL will be reset
-    peerTTL: 48h
+    peerTTL: 720h
     # taskGCInterval is the interval of task gc. If all the peers have been reclaimed in the task,
     # then the task will also be reclaimed.
     taskGCInterval: 30m
     # hostGCInterval is the interval of host gc.
-    hostGCInterval: 6h
+    hostGCInterval: 5m
     # hostTTL is time to live of host. If host announces message to scheduler,
     # then HostTTl will be reset.
     hostTTL: 1h


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes significant updates to the scheduler configuration documentation to reflect changes in various timeout and interval settings. The most important changes involve increasing the `peerTTL` and modifying the intervals for peer garbage collection (`peerGCInterval`) and host garbage collection (`hostGCInterval`).

### Updates to scheduler configuration:

* [`peerGCInterval`](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48L79-R87): Changed from `10s` to `5m`, significantly increasing the interval for peer garbage collection.
* [`peerTTL`](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48L79-R87): Changed from `48h` to `720h`, extending the time-to-live for peers.
* [`hostGCInterval`](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48L79-R87): Changed from `6h` to `5m`, reducing the interval for host garbage collection.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
