### PR TITLE
docs: change taskTTL from 21600s to 720h

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -158,7 +158,7 @@ gc:
   interval: 900s
   policy:
     # taskTTL is the ttl of the task.
-    taskTTL: 21600s
+    taskTTL: 720h
     # # distThreshold optionally defines a specific disk capacity to be used as the base for
     # # calculating GC trigger points with `distHighThresholdPercent` and `distLowThresholdPercent`.
     # #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the configuration documentation for the `gc` section in `dfdaemon.md`, specifically changing the `taskTTL` value from seconds to hours for improved readability and clarity.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
