### PR TITLE
docs: support http protocol config for otel

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -260,10 +260,15 @@ metrics:
     port: 4002
   # # ip is the listen ip of the metrics server.
   # ip: ""
-# # tracing is the tracing configuration for dfdaemon.
+
+# tracing is the tracing configuration for dfdaemon.
 # tracing:
-# # addr is the address to report tracing log.
-# addr: ""
-# # headers is the grpc's headers to send with tracing log.
-# headers: {}
+#   # Protocol specifies the communication protocol for the tracing server.
+#   # Supported values: "http", "https", "grpc" (default: None).
+#   # This determines how tracing logs are transmitted to the server.
+#   protocol: grpc
+#   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+#   endpoint: localhost:4317
+#   # headers is the grpc's headers to send with tracing log.
+#   headers: {}
 ```

--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -190,7 +190,14 @@ verbose: true
 # default is -1. If it is 0, pprof will use a random port.
 pprof-port: -1
 
-tracing:
-  # Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
-  addr: ''
+# tracing is the tracing configuration for dfdaemon.
+# tracing:
+#   # Protocol specifies the communication protocol for the tracing server.
+#   # Supported values: "http", "https", "grpc" (default: None).
+#   # This determines how tracing logs are transmitted to the server.
+#   protocol: grpc
+#   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+#   endpoint: localhost:4317
+#   # headers is the grpc's headers to send with tracing log.
+#   headers: {}
 ```

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -180,7 +180,14 @@ verbose: true
 # default is -1. If it is 0, pprof will use a random port.
 pprof-port: -1
 
-tracing:
-  # Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
-  addr: ''
+# tracing is the tracing configuration for dfdaemon.
+# tracing:
+#   # Protocol specifies the communication protocol for the tracing server.
+#   # Supported values: "http", "https", "grpc" (default: None).
+#   # This determines how tracing logs are transmitted to the server.
+#   protocol: grpc
+#   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
+#   endpoint: localhost:4317
+#   # headers is the grpc's headers to send with tracing log.
+#   headers: {}
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the tracing configuration across multiple documentation files to provide more detailed and standardized options. The changes include replacing the previous `addr` field with new fields like `protocol`, `endpoint`, and `headers` to enhance clarity and flexibility in configuring tracing logs.

### Updates to tracing configuration:

* **`docs/reference/configuration/client/dfdaemon.md`**: Added fields `protocol`, `endpoint`, and `headers` to specify the communication protocol, server endpoint, and headers for tracing logs. Removed the older `addr` field.
* **`docs/reference/configuration/manager.md`**: Updated tracing configuration with the same new fields (`protocol`, `endpoint`, `headers`) and removed the `addr` field for consistency.
* **`docs/reference/configuration/scheduler.md`**: Standardized tracing configuration by introducing `protocol`, `endpoint`, and `headers` fields, replacing the `addr` field.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
