### PR TITLE
docs(observability): add protocol for jaeger config

### DIFF
--- a/docs/operations/best-practices/observability/tracing.md
+++ b/docs/operations/best-practices/observability/tracing.md
@@ -28,8 +28,10 @@ docker run --rm --name jaeger \
 
 ```yaml
 tracing:
+  # Protocol to use for tracing.
+  protocol: grpc
   # Jaeger endpoint url, like: jaeger.dragonfly.svc:4317.
-  addr: jaeger.dragonfly.svc:4317
+  endpoint: jaeger.dragonfly.svc:4317
 ```
 
 #### Access the Jaeger UI


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the tracing configuration documentation to improve clarity and align with the latest protocol standards.

Documentation updates:

* [`docs/operations/best-practices/observability/tracing.md`](diffhunk://#diff-689f48655cbfae9200e68f2f86088bf739ebca10e01febb57f932595cfe140dcR31-R34): Added a `protocol` field to specify the tracing protocol (e.g., `grpc`) and replaced the `addr` field with `endpoint` for better naming consistency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
