### PR TITLE
docs: remove verbose and add logLevel and collectedPieceTimeout for config

### DIFF
--- a/docs/development-guide/configure-development-nvironment.md
+++ b/docs/development-guide/configure-development-nvironment.md
@@ -13,7 +13,7 @@ This document describes how to configure a local development environment for Dra
 | Name     | Version                      | Document                                                                     |
 | -------- | ---------------------------- | ---------------------------------------------------------------------------- |
 | Git      | 1.9.1+                       | [git-scm](https://git-scm.com/)                                              |
-| Golang   | 1.23.8+                       | [go.dev](https://go.dev/)                                                    |
+| Golang   | 1.23.8+                      | [go.dev](https://go.dev/)                                                    |
 | Rust     | 1.6+                         | [rustup.rs](https://rustup.rs/)                                              |
 | Database | Mysql 5.6+ OR PostgreSQL 12+ | [mysql](https://www.mysql.com/) OR [postgresql](https://www.postgresql.org/) |
 | Redis    | 3.0+                         | [redis.io](https://redis.io/)                                                |
@@ -76,7 +76,7 @@ Run Manager:
 
 ```bash
 # Setup Manager.
-go run cmd/manager/main.go --config /etc/dragonfly/manager.yaml --verbose --console
+go run cmd/manager/main.go --config /etc/dragonfly/manager.yaml --console
 ```
 
 #### Verify {#verify-manager}
@@ -123,7 +123,7 @@ Run Scheduler:
 
 ```bash
 # Setup Scheduler.
-go run cmd/scheduler/main.go --config /etc/dragonfly/scheduler.yaml --verbose --console
+go run cmd/scheduler/main.go --config /etc/dragonfly/scheduler.yaml --console
 ```
 
 #### Verify {#verify-scheduler}
@@ -161,7 +161,7 @@ Run Dfdaemon as Seed Peer:
 
 ```bash
 # Setup Dfdaemon.
-cargo run --bin dfdaemon -- --config /etc/dragonfly/dfdaemon.yaml -l info --verbose
+cargo run --bin dfdaemon -- --config /etc/dragonfly/dfdaemon.yaml -l info --console
 ```
 
 #### Verify {#verify-seed-peer}
@@ -195,7 +195,7 @@ Run Dfdaemon as Peer:
 
 ```bash
 # Setup Dfdaemon.
-cargo run --bin dfdaemon -- --config /etc/dragonfly/dfdaemon.yaml -l info --verbose
+cargo run --bin dfdaemon -- --config /etc/dragonfly/dfdaemon.yaml -l info --console
 ```
 
 #### Verify {#verify-peer}

--- a/docs/getting-started/installation/binaries.md
+++ b/docs/getting-started/installation/binaries.md
@@ -180,7 +180,7 @@ $ sudo systemctl status dfdaemon
      Memory: 15.0M (max: 8.0G available: 7.9G)
         CPU: 83ms
      CGroup: /system.slice/dfdaemon.service
-             └─2118 /usr/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --verbose
+             └─2118 /usr/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --console
 ```
 
 #### Step 4: Use Dfget to download files {#dfget-to-download-files-rpm}
@@ -261,7 +261,7 @@ $ sudo systemctl status dfdaemon
      Memory: 15.0M (max: 8.0G available: 7.9G)
         CPU: 83ms
      CGroup: /system.slice/dfdaemon.service
-             └─2118 /usr/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --verbose
+             └─2118 /usr/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --console
 ```
 
 #### Step 4: Use Dfget to download files {#dfget-to-download-files-deb}

--- a/docs/reference/commands/manager.md
+++ b/docs/reference/commands/manager.md
@@ -35,7 +35,6 @@ version     show version
     --config string         the path of configuration file with yaml extension name, default is /etc/dragonfly/manager.yaml, it can also be set by env var: MANAGER_CONFIG
     --console               whether logger output records to the stdout
 -h, --help                  help for manager
-    --verbose               whether logger use debug level
 ```
 
 <!-- markdownlint-restore -->

--- a/docs/reference/commands/scheduler.md
+++ b/docs/reference/commands/scheduler.md
@@ -35,7 +35,6 @@ version     show version
       --config string         the path of configuration file with yaml extension name, default is /etc/dragonfly/scheduler.yaml, it can also be set by env var: SCHEDULER_CONFIG
       --console               whether logger output records to the stdout
   -h, --help                  help for scheduler
-      --verbose               whether logger use debug level
 ```
 
 <!-- markdownlint-restore -->

--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -43,6 +43,8 @@ download:
   rateLimit: 50GiB
   # pieceTimeout is the timeout for downloading a piece from source.
   pieceTimeout: 60s
+  # collectedPieceTimeout is the timeout for collecting one piece from the parent in the stream.
+  collectedPieceTimeout: 10s
   # concurrentPieceCount is the number of concurrent pieces to download.
   concurrentPieceCount: 10
 

--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -46,6 +46,10 @@ server:
   # In linux, default value is /usr/local/dragonfly.
   # In macos(just for testing), default value is /Users/$USER/.dragonfly.
   workHome: ''
+  # logLevel specifies the logging level for the manager.
+  # Default: "info"
+  # Supported values: "debug", "info", "warn", "error", "panic", "fatal"
+  logLevel: "info"
   # logDir is the log directory.
   # In linux, default value is /var/log/dragonfly.
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
@@ -183,12 +187,8 @@ network:
 # Console shows log on console.
 console: true
 
-# Whether to enable debug level logger and enable pprof.
-verbose: true
-
-# Listen port for pprof, only valid when the verbose option is true
-# default is -1. If it is 0, pprof will use a random port.
-pprof-port: -1
+# Listen port for pprof, default is -1 (meaning disabled).
+pprofPort: -1
 
 # tracing is the tracing configuration for dfdaemon.
 # tracing:

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -36,6 +36,10 @@ server:
   # In linux, default value is /usr/local/dragonfly.
   # In macos(just for testing), default value is /Users/$USER/.dragonfly.
   workHome: ''
+  # logLevel specifies the logging level for the scheduler.
+  # Default: "info"
+  # Supported values: "debug", "info", "warn", "error", "panic", "fatal"
+  logLevel: "info"
   # logDir is the log directory.
   # In linux, default value is /var/log/dragonfly.
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/logs.
@@ -173,12 +177,8 @@ network:
 # Console shows log on console.
 console: true
 
-# Whether to enable debug level logger and enable pprof.
-verbose: true
-
-# Listen port for pprof, only valid when the verbose option is true
-# default is -1. If it is 0, pprof will use a random port.
-pprof-port: -1
+# Listen port for pprof, default is -1 (meaning disabled).
+pprofPort: -1
 
 # tracing is the tracing configuration for dfdaemon.
 # tracing:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request primarily focuses on removing the `--verbose` flag and replacing it with the `--console` flag across multiple components, as well as introducing new configuration options for logging and timeout settings. The changes aim to simplify logging behavior and enhance configurability.

### Removal of `--verbose` Flag:
* [`docs/development-guide/configure-development-nvironment.md`](diffhunk://#diff-2af4388890fa6a666a4b75f5374711be850c6d8a4b4adf055e48456656d3550cL79-R79): Updated command examples for Manager, Scheduler, and Dfdaemon to remove the `--verbose` flag and use `--console` instead. [[1]](diffhunk://#diff-2af4388890fa6a666a4b75f5374711be850c6d8a4b4adf055e48456656d3550cL79-R79) [[2]](diffhunk://#diff-2af4388890fa6a666a4b75f5374711be850c6d8a4b4adf055e48456656d3550cL126-R126) [[3]](diffhunk://#diff-2af4388890fa6a666a4b75f5374711be850c6d8a4b4adf055e48456656d3550cL164-R164) [[4]](diffhunk://#diff-2af4388890fa6a666a4b75f5374711be850c6d8a4b4adf055e48456656d3550cL198-R198)
* [`docs/getting-started/installation/binaries.md`](diffhunk://#diff-ba2253bd310cc425e8aa1cf1320333a9a758e051b30c411292e6ba0806b307ffL183-R183): Replaced `--verbose` with `--console` in `dfdaemon` service examples. [[1]](diffhunk://#diff-ba2253bd310cc425e8aa1cf1320333a9a758e051b30c411292e6ba0806b307ffL183-R183) [[2]](diffhunk://#diff-ba2253bd310cc425e8aa1cf1320333a9a758e051b30c411292e6ba0806b307ffL264-R264)
* `docs/reference/commands/manager.md` and `docs/reference/commands/scheduler.md`: Removed the `--verbose` flag from the command reference documentation. [[1]](diffhunk://#diff-19acdcdeb1a664577184b9b451d842acf2b64aa70ced38ba05dea2951bdc7084L38) [[2]](diffhunk://#diff-192782718709e0eb11c04e100291889d4dc8a636979fe77e9c1963ebd7027a3dL38)

### Logging Improvements:
* `docs/reference/configuration/manager.md` and `docs/reference/configuration/scheduler.md`: Added a new `logLevel` configuration option to specify logging levels (`debug`, `info`, `warn`, `error`, `panic`, `fatal`) with a default value of `info`. [[1]](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cR49-R52) [[2]](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48R39-R42)

### Timeout Enhancements:
* [`docs/reference/configuration/client/dfdaemon.md`](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bR46-R47): Introduced a new `collectedPieceTimeout` setting to define the timeout for collecting a piece from the parent in the stream.

### Debugging Configuration Changes:
* `docs/reference/configuration/manager.md` and `docs/reference/configuration/scheduler.md`: Removed the `verbose` option and its associated `pprof-port`. Added `pprofPort` as a standalone configuration for enabling pprof with a default value of `-1` (disabled). [[1]](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cL186-R191) [[2]](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48L176-R181)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
