### PR TITLE
docs: add path field for tracing config

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -271,6 +271,8 @@ metrics:
 #   protocol: grpc
 #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
 #   endpoint: localhost:4317
+#   # path is the path to report tracing log, example: "/v1/traces" if the protocol is "http" or "https".
+#   path: "/v1/traces"
 #   # headers is the grpc's headers to send with tracing log.
 #   headers: {}
 ```

--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -198,6 +198,8 @@ pprofPort: -1
 #   protocol: grpc
 #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
 #   endpoint: localhost:4317
+#   # path is the path to report tracing log, example: "/v1/traces" if the protocol is "http" or "https".
+#   path: "/v1/traces"
 #   # headers is the grpc's headers to send with tracing log.
 #   headers: {}
 ```

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -188,6 +188,8 @@ pprofPort: -1
 #   protocol: grpc
 #   # endpoint is the endpoint to report tracing log, example: "localhost:4317".
 #   endpoint: localhost:4317
+#   # path is the path to report tracing log, example: "/v1/traces" if the protocol is "http" or "https".
+#   path: "/v1/traces"
 #   # headers is the grpc's headers to send with tracing log.
 #   headers: {}
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new configuration option, `path`, for specifying the path to report tracing logs when using HTTP or HTTPS protocols. The changes are applied consistently across multiple configuration reference files.

### Updates to configuration documentation:

* [`docs/reference/configuration/client/dfdaemon.md`](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bR274-R275): Added the `path` option under the `metrics` section to specify the path for tracing logs.
* [`docs/reference/configuration/manager.md`](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cR201-R202): Added the `path` option under the `metrics` section to specify the path for tracing logs.
* [`docs/reference/configuration/scheduler.md`](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48R191-R192): Added the `path` option under the `metrics` section to specify the path for tracing logs.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
