### PR TITLE
docs: add blog posts for Dragonfly and Nydus releases and integrations 📝

### DIFF
--- a/blog/2023-03-20-dragonfly-v2-0-9-is-released/index.md
+++ b/blog/2023-03-20-dragonfly-v2-0-9-is-released/index.md
@@ -1,0 +1,68 @@
+---
+title: Dragonfly v2.0.9 is released
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+
+<!-- Posted on March 20, 2023 -->
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/03/20/dragonfly-v2-0-9-is-released/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+ <!-- [![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg)](https://www.cncf.io/projects/dragonfly "Go to Dragonfly")[![Kubernetes logo](https://landscape.cncf.io/logos/e0303fdc381c96c1b4461ad1a2437c8f050cfb856fcb8710c9104367ca60f316.svg) ](https://www.cncf.io/projects/kubernetes "Go to Kubernetes")[![Volcano logo](https://landscape.cncf.io/logos/45984434efdb609308838359d65422b44b2c60579df44a3f56c642b4161660d1.svg)](https://www.cncf.io/projects/volcano "Go to Volcano") -->
+
+_Project post originally published on [Github](https://github.com/dragonflyoss/Dragonfly2/releases/tag/v2.0.9) by Dragonfly maintainers_
+
+![Dragonfly provide efficient, stable, secure file distribution and image acceleration based on p2p technology to be the best practice and standard solution in cloud native architectures. It is hosted by the Cloud Native Computing Foundation (CNCF) as an Incubating Level Project](https://www.cncf.io/wp-content/uploads/2023/03/20230317123413.jpg)
+
+Dragonfly v2.0.9 is released! 🎉🎉🎉 Thanks to the [Google Cloud Platform](https://cloud.google.com/) (GCP) Team, [Volcano Engine](https://www.volcengine.com/) Team, and [Baidu AI Cloud](https://intl.cloud.baidu.com/) Team for helping Dragonfly integrate with their public clouds. Welcome to visit [d7y.io](https://d7y.io/) website.
+
+![Github snippit](https://www.cncf.io/wp-content/uploads/2023/03/image-7.jpg)
+
+## **Features**
+
+- Download tasks based on priority. Priority can be passed as parameter during the download task, or can be associated with priority in the application of the Manager console, refer to priority [protoc definition](https://github.com/dragonflyoss/api/blob/main/pkg/apis/common/v2/common.proto#L74).
+- Scheduler adds PieceDownloadTimeout parameter, which indicates that if the piece download times out, the scheduler will change the task state to TaskStateFailed.
+- Add health service to each GRPC service.
+- Add reflection to each GRPC service.
+- Manager supports redis sentinal model.
+- Refactor dynconfig package to remove json.Unmarshal, improving its runtime efficiency.
+- Fix panic caused by hashring not being built.
+- Previously, most of the pieces were downloaded from the same parent. Now, different pieces are downloaded from different parents to improve download efficiency and distribute bandwidth among multiple parents.
+- If Manager’s searcher can not found candidate scheduler clusters, It will return all the clusters for peers to check health. If check health is successful, the scheduler cluster can be used.
+- Support [ORAS](https://github.com/oras-project/oras) source client to pull image.
+- Add UDP ping package and GRPC protoc definition for building virtual network topology.
+- The [V2 P2P protocol](https://github.com/dragonflyoss/api/tree/main/proto) has been added, and both Scheduler and Manager have implemented the API of the V2 P2P protocol, in preparation for the future Rust version of Dfdaemon.
+- OSS source client supports STS access, user can set security token in header.
+- Dynconfig supports to resolve addresses with health service.
+- Add hostTTL and hostGCInterval in Scheduler to prevent information of abnormally exited Dfdaemon from becoming dirty data in the Scheduler.
+- Add [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) to searcher to provide more precise scheduler cluster selection for Dfdaemon.
+- Refactor the metric definitions for the V1 P2P protocol and add the metric definitions for the V2 P2P protocol. Additionally, reorganize the [Dragonfly Grafana Dashboards](https://grafana.com/grafana/dashboards/?search=dragonfly), refer to [monitoring](https://d7y.io/docs/concepts/observability/monitoring).
+
+## **Break Change**
+
+- Using the default value for the key used to generate JWT tokens in Manager can lead to security issues. Therefore, Manager has added [JWT Key](https://github.com/dragonflyoss/Dragonfly2/pull/2161) in the configuration, and upgrading Manager requires generating a new JWT Key and setting it in the [Manager configuration](https://github.com/dragonflyoss/d7y.io/blob/main/docs/reference/configuration/manager.md?plain=1#L56).
+
+## **Public Cloud Providers**
+
+- **_Google Cloud Platform(GCP)_** – GCP provides click to deploy Dragonfly in [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) (GKE) through [Marketplace](https://console.cloud.google.com/marketplace/product/google/dragonfly), refer to [Click to Deploy Dragonfly](https://console.cloud.google.com/marketplace/product/google/dragonfly).
+- **_Alibaba Cloud(Aliyun)_** – Aliyun provides install Dragonfly 1.x in [Container Registry](https://console.cloud.google.com/marketplace/product/google/dragonfly), refer to Use P2P Acceleration in [ASK](https://www.alibabacloud.com/help/en/container-registry/latest/use-the-p2p-acceleration-feature-in-ask-and-ack-clusters). **Recommend to deploy the more efficient and stable [Dragonfly 2.0](https://github.com/dragonflyoss/Dragonfly2)**, refer to Setup [Dragonfly in Kubernetes](https://d7y.io/docs/getting-started/quick-start/kubernetes/).
+- **_Volcano Engine_** – Volcano Engine provides Dragonfly integration in Volcano Engine Kubernetes Engine(VKE) and Container Registry(CR), visit [VKE](https://www.volcengine.com/product/vke) & [CR](https://www.volcengine.com/product/cr) to Learn more.
+- **_Baidu AI Cloud_** – Baidu AI Cloud provides click to P2P Acceleration in [Cloud Container Engine](https://intl.cloud.baidu.com/product/cce.html) (CCE), power by Dragonfly.
+
+## **Others**
+
+You can see [CHANGELOG](https://github.com/dragonflyoss/Dragonfly2/blob/main/CHANGELOG.md) for more details.
+
+## **Links**
+
+- Dragonfly Website: [https://d7y.io/](https://d7y.io/)
+- Dragonfly Github: [https://github.com/dragonflyoss/Dragonfly2](https://github.com/dragonflyoss/Dragonfly2)
+- Dragonfly Charts Github: [https://github.com/dragonflyoss/helm-charts](https://github.com/dragonflyoss/helm-charts)
+- Dragonfly Monitor Github: [https://github.com/dragonflyoss/monitoring](https://github.com/dragonflyoss/monitoring)
+- Google Kubernetes Engine(GKE): [https://cloud.google.com/kubernetes-engine](https://cloud.google.com/kubernetes-engine)
+- Google Cloud Platform(GCP) Dragonfly Marketplace: [https://console.cloud.google.com/marketplace/product/google/dragonfly](https://console.cloud.google.com/marketplace/product/google/dragonfly)
+- Alibaba Cloud Container Registry: [https://www.alibabacloud.com/product/container-registry](https://www.alibabacloud.com/product/container-registry)
+- Alibaba Cloud Container Service for Kubernetes (ACK): [https://www.alibabacloud.com/product/kubernetes](https://www.alibabacloud.com/product/kubernetes)
+- Volcano Engine Kubernetes Engine(VKE): [https://www.volcengine.com/product/vke](https://www.volcengine.com/product/vke)
+- Volcano Engine Container Registry(CR): [https://www.volcengine.com/product/cr](https://www.volcengine.com/product/cr)
+- Baidu AI Cloud Cloud Container Engine(CCE): [https://intl.cloud.baidu.com/product/cce.html](https://intl.cloud.baidu.com/product/cce.html)

--- a/blog/2023-04-13-volcano-engine-distributed-image-acceleration-practice-based-on-dragonfly/index.md
+++ b/blog/2023-04-13-volcano-engine-distributed-image-acceleration-practice-based-on-dragonfly/index.md
@@ -1,0 +1,226 @@
+---
+title: Volcano Engine, distributed image acceleration practice based on Dragonfly
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+
+<!-- Posted on April 13, 2023 -->
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/04/13/volcano-engine-distributed-image-acceleration-practice-based-on-dragonfly/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+ <!-- [![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg)](https://www.cncf.io/projects/dragonfly "Go to Dragonfly")[![Kubernetes logo](https://landscape.cncf.io/logos/e0303fdc381c96c1b4461ad1a2437c8f050cfb856fcb8710c9104367ca60f316.svg) ](https://www.cncf.io/projects/kubernetes "Go to Kubernetes")[![Volcano logo](https://landscape.cncf.io/logos/45984434efdb609308838359d65422b44b2c60579df44a3f56c642b4161660d1.svg)](https://www.cncf.io/projects/volcano "Go to Volcano") -->
+
+<!-- _Project post by Gaius, Dragonfly Maintainer_ -->
+
+Terms and definitions
+
+| Term               | Definition                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OCI                | The Open Container Initiative is a Linux Foundation project launched by Docker in June 2015 to design open standards for operating system-level virtualization (and most importantly Linux containers).                                                                                                                                                                                                                                                                                                                    |
+| OCI Artifact       | Products that follow the OCI image spec.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Image              | The image in this article refers to OCI Artifact                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Image Distribution | A product distribution implemented according to the OCI distribution spec.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ECS                | It is a collection of resources composed of CPU, memory, and Cloud Drive, each of which logically corresponds to the computing hardware entity of the Data center infrastructure.                                                                                                                                                                                                                                                                                                                                          |
+| CR                 | Volcano Engine image distribution service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| VKE                | Volcano Engine deeply integrates the new generation of Cloud Native technology to provide high-performance Kubernetes container cluster management services with containers as the core, helping users to quickly build containerized applications.                                                                                                                                                                                                                                                                        |
+| VCI                | Volcano is a serverless and containerized computing service. The current VCI seamlessly integrates with the Container Service VKE to provide Kubernetes orchestration capabilities. With VCI, you can focus on building the app itself, without having to buy and manage infrastructure such as the underlying Cloud as a Service, and pay only for the resources that the container actually consumes to run. VCI also supports second startup, high concurrent creation, sandbox Container Security isolation, and more. |
+| TOS                | Volcano Engine provides massive, secure, low-cost, easy-to-use, highly reliable and highly available distributed cloud storage services.                                                                                                                                                                                                                                                                                                                                                                                   |
+| Private Zone       | Private DNS service based on a proprietary network VPC (Virtual Private Cloud) environment. This service allows private domain names to be mapped to IP addresses in one or more custom VPCs.                                                                                                                                                                                                                                                                                                                              |
+| P2P                | Peer-to-peer technology, when a peer in a P2P network downloads data from the server, it can also be used as a server level for other peers to download after downloading the data. When a large number of nodes download at the same time, it can ensure that the subsequent downloaded data does not need to be downloaded from the server side. Thereby reducing the pressure on the server side.                                                                                                                       |
+| Dragonfly          | Dragonfly is a file distribution and image acceleration system based on P2P technology, and is the standard solution and best practice in the field of image acceleration in Cloud Native architecture. Now hosted as an incubation project by the Cloud Native Computing Foundation (CNCF).                                                                                                                                                                                                                               |
+| Nydus              | Nydus Acceleration Framework implements a content-addressable filesystem that can accelerate container image startup by lazy loading. It has supported the creation of millions of accelerated image containers daily, and deeply integrated with the linux kernel's erofs and fscache, enabling in-kernel support for image acceleration.                                                                                                                                                                                 |
+
+## Background
+
+Volcano Engine image repository CR uses TOS to store container images. Currently, it can meet the demand of large-scale concurrent image pulling to a certain extent. However, the final concurrency of pulling is limited by the bandwidth and QPS of TOS.
+
+Here is a brief introduction of the two scenarios that are currently encountered for large-scale image pulling:
+
+1. The number of clients is increasing, and the images are getting larger. The bandwidth of TOS will eventually be insufficient.
+2. If the client uses Nydus to convert the image format, the request volume to TOS will increase by an order of magnitude. The QPS limit of TOS API makes it unable to meet the demand.
+
+Whether it is the image repository service itself or the underlying storage, there will be bandwidth and QPS limitations in the end. If you rely solely on the bandwidth and QPS provided by the server, it is easy to be unable to meet the demand. Therefore, P2P needs to be introduced to reduce server pressure and meet the demand for large-scale concurrent image pulling.
+
+Investigation of image distribution system based on P2P technology
+
+There are several P2P projects in the open source community. Here is a brief introduction to these projects.
+
+[Dragonfly](https://github.com/dragonflyoss/Dragonfly2)
+
+Architecture
+
+![Diagram flow showing Dragonfly architecture](https://www.cncf.io/wp-content/uploads/2023/04/image1-49.png)
+
+Manager
+
+- Stores dynamic configuration for consumption by seed peer cluster, scheduler cluster and dfdaemon.
+- Maintain the relationship between seed peer cluster and scheduler cluster.
+- Provide async task management features for image preheat combined with harbor.
+- Keepalive with scheduler instance and seed peer instance.
+- Filter the optimal scheduler cluster for dfdaemon.
+- Provides a visual console, which is helpful for users to manage the P2P cluster.
+
+Scheduler
+
+- Based on the multi-feature intelligent scheduling system selects the optimal parent peer.
+- Build a scheduling directed acyclic graph for the P2P cluster.
+- Remove abnormal peer based on peer multi-feature evaluation results.
+- In the case of scheduling failure, notice peer back-to-source download.
+
+Dfdaemon
+
+- Serve gRPC for dfget with downloading feature, and provide adaptation to different source protocols.
+- It can be used as seed peer. Turning on the Seed Peer mode can be used as a back-to-source download peer in a P2P cluster, which is the root peer for download in the entire cluster.
+- Serve proxy for container registry mirror and any other http backend.
+- Download object like via http, https and other custom protocol.
+
+[Kraken](https://github.com/uber/kraken)
+
+Architecture
+
+![Diagram flow showing Kraken architecture](https://www.cncf.io/wp-content/uploads/2023/04/image2-48.jpg)
+
+Agent
+
+- Is a peer node in a P2P network and needs to be deployed on each node
+- Implemented the docker registry interface
+- Notify the tracker of the data they own
+- Download the data of other agents (the tracker will tell the agent which agent to download this data from)
+
+Origin
+
+- Responsible for reading data from storage for seeding
+- Support for different storage
+- High availability in the form of a hash ring
+
+Tracker
+
+- A coordinator in a P2P network, tracking who is a peer and who is a seeder
+- Track data owned by peers
+- Provide ordered peer nodes for peers to download data
+- High availability in the form of a hash ring
+
+Proxy
+
+- Implemented the docker registry interface
+- Pass the image layer to the Origin component
+- Pass the tag to the build-index component
+
+Build-Index
+
+- Tag and digest mapping, when the agent downloads the corresponding tag data, it obtains the corresponding digest value from Build-Index
+- image replication between clusters
+- Save tag data in storage
+- High availability in the form of a hash ring
+
+Dragonfly vs Kraken
+
+|                           | Dragonfly                                                 | Kraken                                                                   |
+| ------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
+| High availability         | Scheduler consistent hash ring supports high availability | Tracker consistent hash ring, multiple replicas ensure high availability |
+| Containerd support        | Support                                                   | Support                                                                  |
+| HTTPS image repository    | Support                                                   | Support                                                                  |
+| Community active level    | Active                                                    | Inactive                                                                 |
+| Number of users           | More                                                      | Less                                                                     |
+| Maturity                  | High                                                      | High                                                                     |
+| Is it optimized for Nydus | Yes                                                       | No                                                                       |
+| Architecture complexity   | Middle                                                    | Middle                                                                   |
+
+Summary
+
+Based on the overall maturity of the project, community active level, number of users, architecture complexity, whether it is optimized for Nydus , future development trends and other factors, Dragonfly is the best choice in P2P projects.
+
+Proposal
+
+For Volcano Engine, the main consideration is that VKE and VCI pull images through CR.
+
+- The product feature of VKE is K8s deployed based on ECS, so it is very suitable to deploy dfdaemon on each node, fully utilize the bandwidth of each node, and then fully utilize the capability of P2P.
+- The product feature of VCI is that there are some virtual nodes with abundant resources at the bottom layer. The upper layer service is based on POD as the carrier, so it is impossible to deploy dfdaemon on each node like VKE, so the deployment form deploys several dfdaemon as cache, using the cache capability.
+- VKE or VCI client pulls images that have been converted by Nydus format. In this scenario, dfdaemon needs to be used as a cache, and not too many nodes should be used to avoid putting too much scheduling pressure on the Scheduler.
+
+Based on Volcano Engine’s demand for the above products, and combined with Dragonfly’s characteristics, a deployment scheme compatible with many factors needs to be designed. The scheme for deploying Dragonfly is designed as follows.
+
+Architecture
+
+![Diagram flow showing Volcano Engine architecture combined with Dragonfly's characteristics](https://www.cncf.io/wp-content/uploads/2023/04/image9-12.png)
+
+- Volcano Engine resources belong to the main account, P2P control components divided by the main account level isolation, each master account under a set of P2P control components. server level implementation of P2PManager controller, through the controller to control the control plane of all P2P cgroup parts
+- P2P control components are deployed in CR data plane VPC , through LB exposed to user cluster
+- On a VKE cluster, Dfdaemons are deployed as DaemonSets, with one Dfdaemon deployed on each node.
+- On VCI , Dfdaemon is deployed as Deployment
+- Containerd on ECS accesses Dfdaemon on this node via 127.0.0.1:65001
+- Through a controller component in the user Clustered Deployment , based on the PrivateZone function, generate `<clusterid>`.p2p.volces.com domain name in the user cluster, the controller will select the Dfdaemon  pod of a specific node (including VKE , VCI ) according to certain rules, and resolve to the above domain name in the form of A record.
+- ECS on Nydusd by `<clusterid>`.p2p.volces.com domain name access Dfdaemon
+- The image service Client and Nydusd on VCI access Dfdaemon via `<clusterid>`.p2p.volces.com domain name
+
+Benchmark
+
+Environment
+
+Container Repository : Bandwidth 10Gbit/s
+
+Dragonfly Scheduler: 2 Replicas，Request 1C2G，Limit 4C8G, Bandwidth 6Gbit/s
+
+Dragonfly Manager: 2 Replicas，Request 1C2G，Limit 4C8G, Bandwidth 6Gbit/s
+
+Dragonfly Peer : Limit 2C6G, Bandwidth 6Gbit/s, SSD
+
+Image
+
+Nginx(500M)
+
+TensorFlow(3G)
+
+Component Version
+
+Dragonfly v2.0.8
+
+POD Creation to Container Start
+
+Nginx  pods concurrently consume time from creation to startup for all pods of 50, 100, 200, and 500
+
+![Bar chart showing NGinx Pod Creation to Container Start divided by 50 Pods, 100 Pods, 200 Pods and 500 Pods in OCI v1. Dragonfly, Dragonfly & Nydus](https://www.cncf.io/wp-content/uploads/2023/04/image3-37.png)
+
+TensorFlow  pods concurrently consume time from creation to startup for all pods of 50, 100, 200, 500, respectively
+
+![Bar chart showing TensorFlow Pod Creation to Container Start divided by 50 Pods, 100 Pods, 200 Pods and 500 Pods in OCI v1, Dragonfly ad Dragonfly & Nydus](https://www.cncf.io/wp-content/uploads/2023/04/image7-15.png)
+
+In large-scale image scenarios, using Dragonfly and Dragonfly & Nydus scenarios can save more than 90% of container startup time compared to OCIv1 scenarios. The shorter startup time after using Nydus is due to the lazyload feature, which only needs to pull a small part of the metadata  Pod to start.
+
+### Back-to-source Peak Bandwidth on Container Registry
+
+Nginx Pod concurrent storage peak traffic of 50, 100, 200, and 500, respectively
+
+![Bar Chart showing impact of Nginx on Container Registry divided in 50 Pods, 100 Pods, 200 Pods and 500 Pods in OCI v1, Dragonfly](https://www.cncf.io/wp-content/uploads/2023/04/image4-29.png)
+
+TensorFlow  Pod concurrent storage peak traffic of 50, 100, 200, 500, respectively
+
+![Bar Chart showing impact of TensorFlow on Container Registry divided in 50 Pods, 100 Pods, 200 Pods and 500 Pods in OCI v1, Dragonfly](https://www.cncf.io/wp-content/uploads/2023/04/image5-24.png)
+
+### Back-to-source Traffic on Container Registry
+
+Nginx Pod concurrent 50, 100, 200, 500 back to the source traffic respectively
+
+![Bar Chart showing impact of Nginx on Container Registry divided in 50 Pods, 100 Pods, 200 Pods and 500 Pods in OCI v1, Dragonfly](https://www.cncf.io/wp-content/uploads/2023/04/image6-16.png)
+
+TensorFlow  Pod concurrent 50, 100, 200, 500 back to the source traffic respectively
+
+![Bar Chart showing impact of TensorFlow on Container Registry divided in 50 Pods, 100 Pods, 200 Pods and 500 Pods in OCI v1, Dragonfly](https://www.cncf.io/wp-content/uploads/2023/04/image8-15.png)
+
+In large-scale scenarios, using Dragonfly back to the source pulls a small number of images, and all images in OCIv1 scenarios have to be back to the source, so using Dragonfly back to the source peak and back to the source traffic is much less than OCIv1. And after using Dragonfly, as the number of concurrency increases, the peak and traffic back to the source will not increase significantly.
+
+## Reference
+
+Volcano Engine [https://www.volcengine.com/](https://www.volcengine.com/)
+
+Volcano Engine VKE [https://www.volcengine.com/product/vke](https://www.volcengine.com/product/vke)
+
+Volcano Engine CR [https://www.volcengine.com/product/cr](https://www.volcengine.com/product/cr)
+
+Dragonfly [https://d7y.io/](https://d7y.io/)
+
+Dragonfly Github Repo [https://github.com/dragonflyoss/Dragonfly2](https://github.com/dragonflyoss/Dragonfly2)
+
+Nydus [https://nydus.dev/](https://nydus.dev/)
+
+Nydus Gihtub Repo [https://github.com/dragonflyoss/image-service](https://github.com/dragonflyoss/image-service)

--- a/blog/2023-05-01-ant-group-security-technologys-nydus-and-dragonfly-image-acceleration-practices/index.md
+++ b/blog/2023-05-01-ant-group-security-technologys-nydus-and-dragonfly-image-acceleration-practices/index.md
@@ -1,0 +1,310 @@
+---
+title:  Ant Group security technology’s Nydus and Dragonfly image acceleration practices
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+
+<!-- Posted on May 1, 2023 -->
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/05/01/ant-group-security-technologys-nydus-and-dragonfly-image-acceleration-practices/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+ <!-- [![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg)](https://www.cncf.io/projects/dragonfly "Go to Dragonfly")[![Kubernetes logo](https://landscape.cncf.io/logos/e0303fdc381c96c1b4461ad1a2437c8f050cfb856fcb8710c9104367ca60f316.svg)](https://www.cncf.io/projects/kubernetes "Go to Kubernetes") -->
+
+<!-- _Guest post by Dragonfly maintainers_ -->
+
+## Introduction
+
+[ZOLOZ](https://www.zoloz.com/) is a global security and risk management platform under Ant Group. Through biometric, big data analysis, and artificial intelligence technologies, ZOLOZ provides safe and convenient security and risk management solutions for users and institutions. ZOLOZ has provided security and risk management technology support for more than 70 partners in 14 countries and regions, including China, Indonesia, Malaysia, and the Philippines. It has already covered areas such as finance, insurance, securities, credit, telecommunications, and public services, and has served over 1.2 billion users.
+
+With the explosion of Kubernetes and cloud-native, ZOLOZ applications have begun to be deployed on a large scale on public clouds using containerization. The images of ZOLOZ applications have been maintained and updated for a long time, and both the number of layers and the overall size have reached a large scale (hundreds of MBs or several GBs). In particular, the basic image size of ZOLOZ’s AI algorithm inference application is much larger than that of general application images (PyTorch/PyTorch:1.13.1-CUDA 11.6-cuDNN 8-Runtime on Docker Hub is 4.92GB, compared to CentOS:latest with only about 234MB).
+
+For container cold start, i.e., when there is no image locally, the image needs to be downloaded from the registry before creating the container. In the production environment, container cold start often takes several minutes, and as the scale increases, the registry may be unable to download images quickly due to network congestion within the cluster. Such large images have brought many challenges to application updates and scaling. With the continuous promotion of containerization on public clouds, ZOLOZ applications mainly face three challenges:
+
+1. The algorithm image is large, and pushing it to the cloud image repository takes a long time. During the development process, when testing in the testing environment, developers often hope to iterate quickly and verify quickly. However, every time a branch is modified and released for verification, it takes several tens of minutes, which is very inefficient.
+2. Pulling the algorithm image takes a long time, and pulling many image files during cluster expansion can easily cause the cluster network card to be flooded and affect the normal operation of the business.
+3. The cluster machine takes a long time to start up, making it difficult to meet the needs of sudden traffic increases and elastic automatic scaling.
+
+Although various compromise solutions have been attempted, these solutions all have their shortcomings. Now, in collaboration with multiple technical teams such as Ant Group, Alibaba Cloud, and ByteDance, a more universal solution on public clouds has been developed, which has low transformation costs and good performance, and currently appears to be an ideal solution.
+
+## Terminology
+
+OCI: Open Container Initiative, a Linux Foundation project initiated by Docker in June 2015, aimed at designing open standards for operating system-level virtualization, most importantly Linux containers.
+
+OCI Manifest: The product follows the OCI Image Spec.
+
+BuildKit: A new generation Docker build tool produced by Docker that is more efficient, Dockerfile-independent, and more suitable for cloud-native applications.
+
+Image: In this article, the image refers to OCI Manifest, including Helm Chart and other OCI Manifests.
+
+Image Repository: A product repository implemented in accordance with OCI Distribution Spec.
+
+ECS: A resource collection consisting of CPUs, memory, and cloud disks, with each type of resource logically corresponding to a computing hardware entity in a data center.
+
+ACR: Alibaba Cloud’s image repository service.
+
+ACK: Alibaba Cloud Container Service Kubernetes version provides high-performance and scalable container application management capabilities and supports full lifecycle management of enterprise-level containerized applications.
+
+ACI: Ant Continuous Integration, is a CI/CD efficiency product under the Ant Group’s research and development efficiency umbrella, which is centered around pipelines. With intelligent automated construction, testing, and deployment, it provides a lightweight continuous delivery solution based on code flow to improve the work efficiency of team development.
+
+Private Zone: A private DNS service based on the Virtual Private Cloud (VPC) environment. This service allows private domain names to be mapped to IP addresses in one or more custom VPCs.
+
+P2P: Peer-to-peer technology, when a Peer in a P2P network downloads data from the server, it can also act as a server for other Peers to download after downloading the data. When a large number of nodes are downloading simultaneously, subsequent data downloads can be obtained without downloading from the server. This can reduce the pressure on the server.
+
+Dragonfly: Dragonfly is a file distribution and image acceleration system based on P2P technology and is the standard solution and best practice in the field of image acceleration in cloud-native architecture. It is now hosted by the Cloud Native Computing Foundation (CNCF) as an incubation-level project.
+
+Nydus: Nydus is a sub-project of Dragonfly’s image acceleration framework that provides on-demand loading of container images and supports millions of accelerated image container creations in production environments every day. It has significant advantages over OCIv1 in terms of startup performance, image space optimization, end-to-end data consistency, kernel-level support, etc.
+
+LifseaOS: A lightweight, fast, secure, and image-atomic management container optimization operating system launched by Alibaba Cloud for container scenarios. Compared with traditional operating systems, the number of software packages is reduced by 60%, and the image size is reduced by 70%. The first-time startup time is reduced from over 1 minute to around 2 seconds. It supports image read-only and OSTree technology, versioning management of OS images, and updating software packages or fixed configurations on the operating system on an image-level basis.
+
+## Solution
+
+### 1: Large image size
+
+#### Reduce the size of the base image
+
+The basic OS is changed from CentOS 7 to AnolisOS 8, and the installation of maintenance tools is streamlined. Only a list of essential tools (basic maintenance tools, runtime dependencies, log cleaning, security baselines, etc.) is installed by default, and the configuration of security hardening is simplified. The base image is reduced from 1.63GB to 300MB.
+
+AnolisOS Repository: [https://hub.docker.com/r/openanolis/anolisos/tags](https://hub.docker.com/r/openanolis/anolisos/tags)
+
+#### Dockerfile optimization
+
+Reduce unnecessary build resources and time through Dockerfile writing constraints, image inspection, and other means.
+
+Dockerfile Best Practices: [https://docs.docker.com/develop/develop-images/dockerfile\_best-practices/](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+
+#### Parallel building and build caching
+
+AntGroup’s Build Center uses the Nydus community-optimized version of [BuildKit](https://github.com/moby/buildkit/blob/master/docs/nydus.md), which supports layer-level caching. The previous artifacts are accurately referenced and cached, and for Multistage type Dockerfiles, BuildKit can achieve parallel execution between different stages.
+
+### 2: Slow pushing image
+
+#### Use Nydus images for block-level data deduplication
+
+In traditional OCI images, the smallest unit that can be shared between different images is the layer in the image, and the efficiency of deduplication is very low. There may be a lot of duplicate data between layers, even if there are slight differences, they will be treated as different layers. According to the design of deletion files and hard links in OCI Image Spec, there may be files that have been deleted in the upper layer but still exist in the lower layer and are included in the image. In addition, OCI Image uses the tar+gzip format to express the layers in the image, and the tar format does not distinguish between tar archive entries order, which brings a problem that if users build the same image on different machines, they may get different images because of using different file systems, but the substantial content of several different images is completely identical, which leads to a sharp increase in the amount of uploaded and downloaded data.
+
+Issues with OCIv1 and OCIv2 proposals: [https://hackmd.io/@cyphar/ociv2-brainstorm](https://hackmd.io/@cyphar/ociv2-brainstorm)
+
+Nydus image files are divided into file chunks, and the metadata layer is flattened (removing intermediate layers). Each chunk is only saved once in the image, and a base image can be specified as a chunk dictionary for other Nydus images. Based on chunk-level deduplication, it provides low-cost data deduplication capabilities between different images, greatly reducing the amount of uploaded and downloaded data for the images.
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-8.png)
+
+As shown in the figure above, Nydus image 1 and image 2 have the same data blocks B2, C, E1, and F. Image 2 adds E2, G1, H1, and H2. If image 1 already exists in the image repository, image 2 can be built based on image 1. Only E2, G1, H1, and H2 need to be built in one layer, and only this layer needs to be uploaded to the image repository during upload. This achieves the effect of uploading and pulling only file differences, shortens the development cycle.
+
+#### Directly building Nydus images
+
+Currently, in most landing scenarios for acceleration images, the production of acceleration images is based on image conversion. The following two Nydus conversion schemes are currently in place:
+
+##### i. Repository conversion
+
+After a traditional image is built and pushed to the image repository, the conversion action of the image repository is triggered to complete the image conversion. The disadvantage of this approach is that the build and conversion are often done on different machines. After the image is built and pushed, it needs to be pulled to the conversion machine and the output needs to be pushed to the image repository, which adds a complete image circulation process and causes high latency. Also, it occupies the network resources of the image repository. Before the acceleration image conversion is complete, application deployment cannot enjoy the acceleration effect and still needs to pull the entire image.
+
+##### ii. Double version building
+
+After the traditional image is built, it is converted directly on the local build machine. To improve efficiency, the conversion of each layer can be started immediately after the construction of that layer, which can significantly reduce the delay in generating acceleration images. With this approach, conversion can begin without waiting for traditional image upload, and because it is local conversion, compared to approach 1, the cost of transfer between the conversion machine and the image repository can be saved. If the accelerated image corresponding to the base image does not exist, it will be converted; if it exists, pulling can be ignored, but inevitably, pushing always requires twice the data.
+
+##### iii. Direct building
+
+Compared with the two conversion-based schemes mentioned above, directly building Nydus acceleration images has obvious production delays. First, OCI-based image construction is significantly slower than Nydus image construction. Second, conversion is an after-the-fact behavior and there is more or less delay. Third, there is additional data transmission in both schemes. Direct building, on the other hand, has fewer steps, is faster, and saves resources.
+
+It can be seen that the steps and data transmission volume for building acceleration images are significantly reduced. After the construction is completed, the ability of the acceleration image can be directly enjoyed and the speed of application deployment can be greatly improved.
+
+### 3: Slow container startup
+
+#### Nydus images load on demand
+
+The actual usage rate of the image data is very low. For example, [Cern’s paper](https://indico.cern.ch/event/567550/papers/2627182/files/6153-paper.pdf) mentions that only 6% of the content of a general image is actually used. The purpose of on-demand loading is to allow the container runtime to selectively download and extract files from the image layers in the Blob, but the [OCI](https://github.com/opencontainers/image-spec/)/[Docker](https://github.com/moby/moby/blob/master/image/spec/v1.2.md) image specifications package all image layers into a tar or tar.gz archive. This means that even if you want to extract a single file, you still have to scan the entire Blob. If the image is compressed using gzip, it is even more difficult to extract specific files.
+
+![Image](https://www.cncf.io/wp-content/uploads/2023/05/image-6.png)
+
+The [RAFS image format](https://d7y.io/blog/2022/06/06/evolution-of-nydus/) is an archive compression format proposed by Nydus. It separates the data (Blobs) and metadata (Bootstrap) of the container image file system, so that the original image layers only store the data part of the files. Furthermore, the files are divided into chunks according to a certain granularity, and the corresponding chunk data is stored in each layer of Blob. Using chunk granularity refines the deduplication granularity, and allows easier sharing of data between layers and images, and easier on-demand loading. The original image layers only store the data part of the files (i.e. the Blob layer in the figure).
+
+The Blob layer stores the chunk files, which are chunks of file data. For example, a 10MB file can be sliced into 10 1MB blocks, and the offset of each chunk can be recorded in an index. When requesting part of the data from a file, the container runtime can selectively obtain the file from the image repository by combining with the HTTP Range Request supported by the OCI/Docker image repository specification, thus saving unnecessary network overhead. For more details about the Nydus image format, please refer to the [Nydus Image Service project](https://github.com/dragonflyoss/image-service).
+
+The metadata and chunk indexes are combined to form the Meta layer in the figure above, which is the entire filesystem structure that the container can see after all image layers are stacked. It includes the directory tree structure, file metadata, chunk information (block size and offset, as well as metadata such as file name, file type, owner, etc. for each file). With Meta, the required files can be extracted without scanning the entire archive file. In addition, the Meta layer contains a hash tree and the hash of each chunk data block, which ensures that the entire file tree can be verified at runtime, and the signature of the entire Meta layer can be checked to ensure that the runtime data can be detected even if it is tampered with.
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-9.png)
+
+Nydus uses the user-mode file system implementation [FUSE](https://www.kernel.org/doc/html/latest/filesystems/fuse.html) to implement on-demand loading by default. The user-mode Nydus daemon process mounts the Nydus image mount point as the container RootFS directory. When the container generates a file system IO such as read(fd, count), the kernel-mode FUSE driver adds the request to the processing queue. The user-mode Nydus daemon reads and processes the request through the FUSE Device, pulls the corresponding number of Chunk data blocks from the remote Registry, and finally replies to the container through the kernel-mode FUSE. Nydus also implements a layer of local cache, where chunks that have been pulled from the remote are uncompressed and cached locally. The cache can be shared between images on a layer-by-layer basis, or at a chunk level.
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-5.png)
+
+After using Nydus for image acceleration, the startup time of different applications has made a qualitative leap, enabling applications to be launched in a very short time, meeting the requirements of rapid scaling in the cloud.
+
+#### Read-only file system EROFS
+
+When there are many files in the container image, frequent file operations generate a large number of FUSE requests, which causes frequent context switching between kernel-space and user-space, resulting in performance bottlenecks. Based on the kernel-space EROFS file system (originating from Linux 4.19), Nydus has made a series of improvements and enhancements to expand its capabilities in the image scenario. The final result is a kernel-space container image format, Nydus RAFS (Registry Acceleration File System) v6. Compared with the previous format, it has the advantages of block data alignment, more concise metadata, high scalability, and high performance. When all image data is downloaded locally, the FUSE user-space solution can cause the process that accesses the file to frequently trap to user-space, and involves memory copies between kernel-space and user-space.
+
+Furthermore, Nydus supports the EROFS over FS-Cache scheme (Linux 5.19-rc1), where the user-space Nydusd directly writes downloaded chunks into the FS-Cache cache. When the container accesses the data, it can directly read the data through the kernel-space FS-Cache without trapping to user-space. In the container image scenario, this achieves almost lossless performance and stability, outperforming the FUSE user-space solution, and comparable to native file systems (without on-demand loading).
+
+|                              | OCI                       | Fuse + rafsv5             | Fuse + rafsv6            | Fscache + rafsv6          | Fscache + rafsv6 + opt patch |
+| ---------------------------- | ------------------------- | ------------------------- | ------------------------ | ------------------------- | ---------------------------- |
+| e2e startup wordpress        | 11.704s, 11.651s, 11.330s | 5.237s, 5.489s, 5.337s    | 5.094s, 5.382s, 5.314s   | 10.167s, 9.999s, 9.884s   | 4.659s, 4.541s, 4.658s       |
+| e2e startup Hello bench java | 9.2186s, 8.9132s, 8.8412s | 2.8325s, 2.7671s, 2.7671s | 2.7543s, 2.8104, 2.8692s | 4.6904s, 4.7012s, 4.6654s | 2.9691s, 3.0485s, 3.0294s    |
+
+Currently Nydus has supported this scheme in building, running, and kernel-space (Linux 5.19-rc1). For detailed usage, please refer to the [Nydus EROFS FS-Cache user guide](https://github.com/dragonflyoss/image-service/blob/master/docs/nydus-fscache.md). If you want to learn more about the implementation details of Nydus in kernel-space, you can refer to [Nydus Image Acceleration: The Evolutionary Road of the Kernel](https://d7y.io/blog/2022/06/06/evolution-of-nydus/).
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-7.png)
+
+#### Dragonfly P2P Accelerates Image Downloading
+
+Both the image repository service and the underlying storage have bandwidth and QPS limitations. If we rely solely on the bandwidth and QPS provided by the server, it is easy to fail to meet the demand. Therefore, P2P needs to be introduced to relieve server pressure, thereby meeting the demand for large-scale concurrent image pulling. In scenarios where large-scale image pulling is required, using Dragonfly&Nydus can save more than 90% of container startup time compared to using OCIv1.
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-9.png)
+
+The shorter startup time after using Nydus is due to the lazy loading feature of the image, where only a small portion of metadata needs to be pulled for the Pod to start. In large-scale scenarios, the number of images pulled back by Dragonfly is very small. In the OCIv1 scenario, all image pulling requires a return to the source, so the peak return to the source and return to the source traffic using Dragonfly are much less than in the OCIv1 scenario. Furthermore, after using Dragonfly, as the concurrency increases, the peak return to the source and traffic do not increase significantly.
+
+| 1GB random file for TEST |                               |                                           |                               |
+| ------------------------ | ----------------------------- | ----------------------------------------- | ----------------------------- |
+| Concurrency              | Completion time for OCI image | Completion time for Nydus+Dragonfly image | Performance improvement ratio |
+| 1                        | 63s                           | 41s                                       | 53%                           |
+| 5                        | 63s                           | 51s                                       | 23%                           |
+| 50                       | 145s                          | 65s                                       | 123%                          |
+
+### 4: Slow Cluster scaling
+
+#### ACR Image Repository Global Synchronization
+
+To meet customer demand for a high-quality experience and data compliance requirements, ZOLOZ deploys in multiple global sites in the cloud. With the help of ACR image repository for cross-border synchronization acceleration, multiple regions around the world are synchronized to improve the efficiency of container image distribution. Image uploading and downloading are performed within the local data center, so even in countries with poor network conditions, deployments can be made like in local data centers, truly achieving one-click deployment of applications around the world.
+
+#### Use ContainerOS for High-Speed Startup
+
+With cloud-native, customers can rapidly expand resource scaling, and use elasticity to reduce costs. On the cloud, virtual machines need to be scaled quickly and added to the cluster. ContainerOS simplifies the OS startup process and pre-installs necessary container images for cluster management components, reducing the time spent during node startup due to image pulling, greatly improving OS startup speed, and reducing node scaling time in the ACK link. ContainerOS is optimized in the following ways:
+
+- ContainerOS simplifies the OS startup process to effectively reduce OS startup time. The positioning of ContainerOS is an operating system running on a cloud-based virtual machine, which does not involve too many hardware drivers. Therefore, ContainerOS modifies the necessary kernel driver modules to built-in mode. In addition, ContainerOS removes initramfs, and udev rules are greatly simplified, which significantly improves OS startup speed. For example, in the ecs.g7.large ECS instance, the first startup time of LifseaOS is about 2 seconds, while Alinux3 requires more than 1 minute.
+- ContainerOS pre-installs necessary container images for cluster management components to reduce the time spent during node startup due to image pulling. After the ECS node startup is completed, some component container images need to be pulled, which are responsible for performing some basic work in the ACK scenario. For example, the Terway component is responsible for the network, and the node must be in the ready state only when the Terway component container is ready. Therefore, since the long-tail effect of network pulling will cause great time consumption, pre-installing this component in the OS in advance can directly obtain it from the local directory, avoiding the time consumption of pulling images from the network.
+- ContainerOS also improves node elasticity performance by combining ACK control link optimization.
+
+Finally, the end-to-end P90 time consumption from an empty ACK node pool expansion was statistically calculated, starting from the issuance of the expansion request and ending the timing when 90% of the nodes were ready, and compared with CentOS and [Alinux2 Optimized-OS](https://www.alibabacloud.com/help/en/container-service-for-kubernetes/latest/containeros-overview) solutions. ContainerOS has significant performance advantages.
+
+## The overall solution
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-10.png)
+
+1. By using a streamlined base image and following Dockerfile conventions, we can reduce the size of our images.
+2. We can utilize the buildkit provided by Ant Group for multistage and parallel image building, and use caching to speed up repeated builds. When directly building Nydus accelerated images, we can deduplicate by analyzing the repetition between images and only upload the different blocks to remote image repositories.
+3. By utilizing ACR’s global acceleration synchronization capability, we can distribute our images to different repositories around the world for faster pulling.
+4. We can use the Dragonfly P2P network to accelerate the on-demand pulling of Nydus image blocks.
+5. We can use the ContainerOS operating system on our nodes to improve both OS and image startup speed.
+
+![image](https://www.cncf.io/wp-content/uploads/2023/05/image-4.png)
+
+| Time (3GB image as an example) | Build Image | Push Image | Schedule Node | Pull Image |
+| ------------------------------ | ----------- | ---------- | ------------- | ---------- |
+| Before                         | 180s        | 60s        | 506s          | 4m15s      |
+| After                          | 130s        | 1s         | 56s           | 560ms      |
+
+\*Schedule Node: This refers to the time from creating an ECS instance on Alibaba Cloud to the node joining the K8s cluster and becoming Ready. Thanks to the optimization of ContainerOS, this time is reduced significantly.
+
+Through extreme optimization of various stages in the entire R&D process, it is found that after optimization, both R&D efficiency and online stability have been qualitatively improved. Currently, the entire solution has been deployed on both Alibaba Cloud and AWS and has been running stably for three months. In the future, standard deployment environments will be provided by cloud vendors to meet the needs of more types of business scenarios.
+
+## Usage Guide
+
+### Dragonfly installation
+
+```text
+$ helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+$ helm install --wait --timeout 10m --dependency-update --create-namespace --namespace dragonfly-system dragonfly dragonfly/dragonfly --set dfdaemon.config.download.prefetch=true,seedPeer.config.download.prefetch=true
+NAME: dragonfly
+LAST DEPLOYED: Fri Apr  7 10:35:12 2023
+NAMESPACE: dragonfly-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+1. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace dragonfly-system $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace dragonfly-system port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+
+2. Get the dfdaemon port by running these commands:
+  export DFDAEMON_POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=dfdaemon" -o jsonpath={.items[0].metadata.name})
+  export DFDAEMON_CONTAINER_PORT=$(kubectl get pod --namespace dragonfly-system $DFDAEMON_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  You can use $DFDAEMON_CONTAINER_PORT as a proxy port in Node.
+
+3. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+```
+
+For more details, please refer to: [https://d7y.io/zh/docs/setup/integration/nydus](https://d7y.io/zh/docs/setup/integration/nydus)
+
+### Nydus installation
+
+```text
+$ curl -fsSL -o config-nydus.yaml https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/test/testdata/charts/config-nydus.yaml
+$ helm install --wait --timeout 10m --dependency-update --create-namespace --namespace nydus-snapshotter nydus-snapshotter dragonfly/nydus-snapshotter -f config-nydus.yaml
+NAME: nydus-snapshotter
+LAST DEPLOYED: Fri Apr  7 10:40:50 2023
+NAMESPACE: nydus-snapshotter
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+Thank you for installing nydus-snapshotter.
+Your release is named nydus-snapshotter.
+To learn more about the release, try:
+  $ helm status nydus-snapshotter
+  $ helm get all nydus-snapshotter
+```
+
+For more details, please refer to: [https://github.com/dragonflyoss/helm-charts/blob/main/INSTALL.md](https://github.com/dragonflyoss/helm-charts/blob/main/INSTALL.md)
+
+### ContainerOS
+
+ContainerOS has implemented high-speed scaling for elastic expansion scenarios in ACK cluster node pools through the following optimizations:
+
+#### OS Startup Speed Improvement
+
+LifseaOS significantly improves OS startup speed by:
+
+- Removing unnecessary hardware drivers for cloud scenarios
+- Modifying essential kernel driver modules to built-in mode
+- Removing initramfs
+- Simplifying udev rules
+
+These optimizations reduce first boot time from over 1 minute (traditional OS) to approximately 2 seconds.
+
+#### ACK-Specific Optimizations
+
+ContainerOS is customized for ACK environments:
+
+- Pre-installed container images for cluster management components eliminate network pull time
+- ACK control link optimizations:
+  - Adjusted detection frequency for critical logic
+  - Modified system bottleneck thresholds under high load
+
+#### How to Use ContainerOS
+
+When creating a managed node pool for an ACK cluster in the Alibaba Cloud console:
+
+1. Go to the ECS instance OS configuration menu
+2. Select ContainerOS from the dropdown menu
+3. Note: The version number (e.g., "1.24.6") in the OS image name corresponds to your cluster's Kubernetes version
+
+For optimal node scaling performance, refer to ContainerOS documentation on high-speed node scaling.
+
+Nydus Project: [https://nydus.dev/](https://nydus.dev/)
+
+Dragonfly Project: [https://d7y.io/](https://d7y.io/)
+
+## Reference
+
+\[1\]ZOLOZ: [https://www.zoloz.com/](https://www.zoloz.com/)
+
+\[2\]BuildKit: [https://github.com/moby/buildkit/blob/master/docs/nydus.md](https://github.com/moby/buildkit/blob/master/docs/nydus.md)
+
+\[3\]Paper by Cern: [https://indico.cern.ch/event/567550/papers/2627182/files/6153-paper.pdf](https://indico.cern.ch/event/567550/papers/2627182/files/6153-paper.pdf)
+
+\[4\]OCI: [https://github.com/opencontainers/image-spec/](https://github.com/opencontainers/image-spec/)
+
+\[5\]Docker: [https://github.com/moby/moby/blob/master/image/spec/v1.2.md](https://github.com/moby/moby/blob/master/image/spec/v1.2.md)
+
+\[6\]RAFS image format: [https://d7y.io/blog/2022/06/06/evolution-of-nydus/](https://d7y.io/blog/2022/06/06/evolution-of-nydus/)
+
+\[7\]Nydus Image Service project: [https://github.com/dragonflyoss/image-service](https://github.com/dragonflyoss/image-service)
+
+\[8\]FUSE: [https://www.kernel.org/doc/html/latest/filesystems/fuse.html](https://www.kernel.org/doc/html/latest/filesystems/fuse.html)
+
+\[9\]Nydus EROFS fscache user guide: [https://github.com/dragonflyoss/image-service/blob/master/docs/nydus-fscache.md](https://github.com/dragonflyoss/image-service/blob/master/docs/nydus-fscache.md)
+
+\[10\]The path of kernel evolution for Nydus image acceleration: [https://d7y.io/blog/2022/06/06/evolution-of-nydus/](https://d7y.io/blog/2022/06/06/evolution-of-nydus/)\[11\]Alinux2 Optimized-OS: [https://www.alibabacloud.com/help/en/container-service-for-kubernetes/latest/containeros-overview](https://www.alibabacloud.com/help/en/container-service-for-kubernetes/latest/containeros-overview)

--- a/blog/2023-08-07-dragonfly-v2-1-0-is-released/index.md
+++ b/blog/2023-08-07-dragonfly-v2-1-0-is-released/index.md
@@ -1,0 +1,70 @@
+---
+title:  Dragonfly v2.1.0 is released!
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+
+<!-- Posted on August 7, 2023 -->
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+ <!-- [![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg)](https://www.cncf.io/projects/dragonfly "Go to Dragonfly")[![Volcano logo](https://landscape.cncf.io/logos/45984434efdb609308838359d65422b44b2c60579df44a3f56c642b4161660d1.svg)](https://www.cncf.io/projects/volcano "Go to Volcano") -->
+
+<!-- _Project post from the Dragonfly maintainers_ -->
+
+Dragonfly v2.1.0 is released! 🎉🎉🎉 Thanks to the Xinxin Zhao[\[1\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn1) for helping to refactor the console[\[2\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn2) and the manager provides a new console for users to operate Dragonfly. Welcome to visit d7y.io[\[3\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn3) website.
+
+![Announcement screenshot from Github mentioning "Dragonfly v2.1.0 is released!"](https://www.cncf.io/wp-content/uploads/2023/08/image-14.png)
+
+## [#features](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#features) Features
+
+- Console v1.0.0[\[4\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn4) is released and it provides a new console for users to operate Dragonfly.
+- Add network topology feature and it can probe the network latency between peers, providing better scheduling capabilities.
+- Provides the ability to control the features of the scheduler in the manager. If the scheduler preheat feature is not in feature flags, then it will stop providing the preheating in the scheduler.
+- dfstore adds GetObjectMetadatas and CopyObject to supports using Dragonfly as the JuiceFS backend.
+- Add personal access tokens feature in the manager and personal access token contains your security credentials for the restful open api.
+- Add TLS config to manager rest server.
+- Fix dfdaemon fails to start when there is no available scheduler address.
+- Add cluster in the manager and the cluster contains a scheduler cluster and a seed peer cluster.
+- Fix object downloads failed by dfstore when dfdaemon enabled concurrent.
+- Scheduler adds database field in config and moves the redis config to database field.
+- Replace net.Dial with grpc health check in dfdaemon.
+- Fix filtering and evaluation in scheduling. Since the final length of the filter is the candidateParentLimit used, the parents after the filter is wrong.
+- Fix storage can not write records to file when bufferSize is zero.
+- Hiding sensitive information in logs, such as the token in the header.
+- Use unscoped delete when destroying the manager’s resources.
+- Add uk\_scheduler index and uk\_seed\_peer index in the table of the database.
+- Remove security domain feature and security feature in the manager.
+- Add advertise port config to manager and scheduler.
+- Fix fsm changes state failed when register task.
+
+## [#break-change](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#break-change) Break Change
+
+- The M:N relationship model between the scheduler cluster and the seed peer cluster is no longer supported. In the future, a P2P cluster will be a cluster in the manager, and a cluster will only include a scheduler cluster and a seed peer cluster.
+
+## [#console](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#console) Console
+
+![Screenshot showing Dragonfly Console welcome back page](https://www.cncf.io/wp-content/uploads/2023/08/image-13.png)
+
+You can see Manager Console[\[5\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn5) for more details.
+
+## [#ai-infrastructure](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#ai-infrastructure) AI Infrastructure
+
+- Triton Inference Server[\[6\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn6) uses Dragonfly to distribute model files, refer to #2185[\[7\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn7). If there are developers who are interested in the drgaonfly repository agent[\[8\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn8) project, please contact [gaius.qi@gmail.com](mailto:gaius.qi@gmail.com).
+- TorchServer[\[9\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn9) uses Dragonfly to distribute model files. Developers have already participated in the dragonfly endpoint[\[10\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn10) project, and the feature will be released in v2.1.1.
+- Fluid[\[11\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn11) downloads data through Dragonfly when running based on JuiceFS[\[12\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn12), the feature will be released in v2.1.1.
+- Dragonfly helps Volcano Engine AIGC inference to accelerate image through p2p technology[\[13\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn13).
+- There have been many cases in the community, using Dragonfly to distribute data in AI scenarios based on P2P technology. In the inference stage, the concurrent download model of the inference service can effectively relieve the bandwidth pressure of the model registry through Dragonfly, and improving the download speed. Community will share topic 《Dragonfly: Intro, Updates and AI Model Distribution in the Practice of Kuaishou – Wenbo Qi, Ant Group & Zekun Liu, Kuaishou Technology》[\[14\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn14) with Kuaishou[\[15\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn15) in KubeCon + CloudNativeCon + Open Source Summit China 2023[\[16\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn16), please follow if interested.
+
+## [#maintainers](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#maintainers) Maintainers
+
+The community has added four new Maintainers, hoping to help more contributors participate in community.
+
+- Yiyang Huang[\[17\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn17): He works for Volcano Engine and will focus on the engineering work for Dragonfly.
+- Manxiang Wen[\[18\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn18): He works for Baidu and will focus on the engineering work for Dragonfly.
+- Mohammed Farooq[\[19\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn19) He works for Intel and will focus on the engineering work for Dragonfly.
+- Zhou Xu[\[20\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn20): He is a PhD student at Dalian University of Technology and will focus on the intelligent scheduling algorithms.
+
+## [#others](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#others) Others
+
+You can see CHANGELOG[\[21\]](https://www.cncf.io/blog/2023/08/07/dragonfly-v2-1-0-is-released/#fn21) for more details.

--- a/blog/2023-09-01-using-dragonfly-to-distribute-images-and-files-for-multi-cluster-kuberenetes/index.md
+++ b/blog/2023-09-01-using-dragonfly-to-distribute-images-and-files-for-multi-cluster-kuberenetes/index.md
@@ -1,0 +1,496 @@
+---
+title:  Using dragonfly to distribute images and files for multi-cluster kuberenetes
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+Posted on September 1, 2023
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/09/01/using-dragonfly-to-distribute-images-and-files-for-multi-cluster-kuberenetes/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+ <!-- [![containerd logo](https://landscape.cncf.io/logos/f26381b645b2f14293a2a597bc98b5bbe1e5e086029de41830ba7c667353bf3e.svg)](https://www.cncf.io/projects/containerd "Go to containerd")[![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg) ](https://www.cncf.io/projects/dragonfly "Go to Dragonfly")[![Jaeger logo](https://landscape.cncf.io/logos/5877af58428f6cd35e6dc2df2afe82af3b90853bd191670a60111e6e8c01ea54.svg) ](https://www.cncf.io/projects/jaeger "Go to Jaeger")[![Kubernetes logo](https://landscape.cncf.io/logos/e0303fdc381c96c1b4461ad1a2437c8f050cfb856fcb8710c9104367ca60f316.svg)](https://www.cncf.io/projects/kubernetes "Go to Kubernetes") -->
+
+Dragonfly provides efficient, stable, securefile distribution and image acceleration based on p2p technology to be the best practice and standard solution in cloud native architectures. It is hosted by the Cloud Native Computing Foundation(CNCF) as an Incubating Level Project.
+
+This article introduces the deployment of dragonfly for multi-cluster kubernetes. A dragonfly cluster manages cluster within a network. If you have two clusters with disconnected networks, you can use two dragonfly clusters to manage their own clusters.
+
+The recommended deployment for multi-cluster kubernetes is to use a dragonfly cluster to manage a kubernetes cluster, and use a centralized manager service to manage multiple dragonfly clusters. Because peer can only transmit data in its own dragonfly cluster, if a kubernetes cluster deploys a dragonfly cluster, then a kubernetes cluster forms a p2p network, and internal peers can only schedule and transmit data in a kubernetes cluster.
+
+![Screenshot showing diagram flow between Network A / Kubernetes Cluster A and Network B / Kubernetes Cluster B towards Manager](https://www.cncf.io/wp-content/uploads/2023/09/image16-5.png)
+
+## Setup kubernetes cluster
+
+[Kind](https://kind.sigs.k8s.io/) is recommended if no Kubernetes cluster is available for testing.
+
+Create kind cluster configuration file kind-config.yaml, configuration content is as follows:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+    extraPortMappings:
+      - containerPort: 30950
+        hostPort: 8080
+    labels:
+      cluster: a
+  - role: worker
+    labels:
+      cluster: a
+  - role: worker
+    labels:
+      cluster: b
+  - role: worker
+    labels:
+      cluster: b
+```
+
+Create cluster using the configuration file:
+
+```bash
+kind create cluster --config kind-config.yaml
+```
+
+Switch the context of kubectl to kind cluster A:
+
+```bash
+kubectl config use-context kind-kind
+```
+
+## Kind loads dragonfly image
+
+Pull dragonfly latest images:
+
+```bash
+docker pull dragonflyoss/scheduler:latest
+docker pull dragonflyoss/manager:latest
+docker pull dragonflyoss/dfdaemon:latest
+```
+
+Kind cluster loads dragonfly latest images:
+
+```bash
+kind load docker-image dragonflyoss/scheduler:latest
+kind load docker-image dragonflyoss/manager:latest
+kind load docker-image dragonflyoss/dfdaemon:latest
+```
+
+## Create dragonfly cluster A
+
+Create dragonfly cluster A, the schedulers, seed peers, peers and centralized manager included in the cluster should be installed using helm.
+
+### Create dragonfly cluster A based on helm charts
+
+Create dragonfly cluster A charts configuration file charts-config-cluster-a.yaml, configuration content is as follows:
+
+```yaml
+containerRuntime:
+  containerd:
+    enable: true
+    injectConfigPath: true
+    registries:
+      - 'https://ghcr.io'
+scheduler:
+  image: dragonflyoss/scheduler
+  tag: latest
+  nodeSelector:
+    cluster: a
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+seedPeer:
+  image: dragonflyoss/dfdaemon
+  tag: latest
+  nodeSelector:
+    cluster: a
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+dfdaemon:
+  image: dragonflyoss/dfdaemon
+  tag: latest
+  nodeSelector:
+    cluster: a
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+manager:
+  image: dragonflyoss/manager
+  tag: latest
+  nodeSelector:
+    cluster: a
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+jaeger:
+  enable: true
+```
+
+Create dragonfly cluster A using the configuration file:
+
+```bash
+$ helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+$ helm install --wait --create-namespace --namespace cluster-a dragonfly dragonfly/dragonfly -f charts-config-cluster-a.yaml
+NAME: dragonfly
+LAST DEPLOYED: Mon Aug  7 22:07:02 2023
+NAMESPACE: cluster-a
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+1. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace cluster-a -l "app=dragonfly,release=dragonfly,component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace cluster-a $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace cluster-a port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+
+2. Get the dfdaemon port by running these commands:
+  export DFDAEMON_POD_NAME=$(kubectl get pods --namespace cluster-a -l "app=dragonfly,release=dragonfly,component=dfdaemon" -o jsonpath={.items[0].metadata.name})
+  export DFDAEMON_CONTAINER_PORT=$(kubectl get pod --namespace cluster-a $DFDAEMON_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  You can use $DFDAEMON_CONTAINER_PORT as a proxy port in Node.
+
+3. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+
+4. Get Jaeger query URL by running these commands:
+  export JAEGER_QUERY_PORT=$(kubectl --namespace cluster-a get services dragonfly-jaeger-query -o jsonpath="{.spec.ports[0].port}")
+  kubectl --namespace cluster-a port-forward service/dragonfly-jaeger-query 16686:$JAEGER_QUERY_PORT
+  echo "Visit http://127.0.0.1:16686/search?limit=20&lookback=1h&maxDuration&minDuration&service=dragonfly to query download events"
+```
+
+Check that dragonfly cluster A is deployed successfully:
+
+```bash
+$ kubectl get po -n cluster-a
+NAME                                 READY   STATUS    RESTARTS      AGE
+dragonfly-dfdaemon-7t6wc             1/1     Running   0             3m18s
+dragonfly-dfdaemon-r45bk             1/1     Running   0             3m18s
+dragonfly-jaeger-84dbfd5b56-fmhh6    1/1     Running   0             3m18s
+dragonfly-manager-75f4c54d6d-tr88v   1/1     Running   0             3m18s
+dragonfly-mysql-0                    1/1     Running   0             3m18s
+dragonfly-redis-master-0             1/1     Running   0             3m18s
+dragonfly-redis-replicas-0           1/1     Running   1 (2m ago)    3m18s
+dragonfly-redis-replicas-1           1/1     Running   0             96s
+dragonfly-redis-replicas-2           1/1     Running   0             45s
+dragonfly-scheduler-0                1/1     Running   0             3m18s
+dragonfly-seed-peer-0                1/1     Running   1 (37s ago)   3m18s
+```
+
+### Create NodePort service of the manager REST service
+
+Create the manager REST service configuration file manager-rest-svc.yaml, configuration content is as follows:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: manager-rest
+  namespace: cluster-a
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      nodePort: 30950
+      port: 8080
+  selector:
+    app: dragonfly
+    component: manager
+    release: dragonfly
+```
+
+Create manager REST service using the configuration file:
+
+```bash
+kubectl apply -f manager-rest-svc.yaml -n cluster-a
+```
+
+### Visit manager console
+
+Visit address localhost:8080 to see the manager console. Sign in the console with the default root user, the username is root and password is dragonfly.
+
+![Screenshot showing Dragonfly welcome back page](https://www.cncf.io/wp-content/uploads/2023/09/image10-8.png)
+
+![Screenshot showing Dragonfly cluster page](https://www.cncf.io/wp-content/uploads/2023/09/image11-7.png)
+
+By default, Dragonfly will automatically create dragonfly cluster A record in manager when it is installed for the first time. You can click dragonfly cluster A to view the details.
+
+![Screenshot showing Cluster-1 page on Dragonfly](https://www.cncf.io/wp-content/uploads/2023/08/Screen-Shot-2023-08-30-at-10.03.31-AM.png)
+
+## Create dragonfly cluster B
+
+Create dragonfly cluster B, you need to create a dragonfly cluster record in the manager console first, and the schedulers, seed peers and peers included in the dragonfly cluster should be installed using helm.
+
+### Create dragonfly cluster B in the manager console
+
+Visit manager console and click the ADD CLUSTER button to add dragonfly cluster B record. Note that the IDC is set to cluster-2 to match the peer whose IDC is cluster-2.
+
+![Screenshot showing Create Cluster page on Dragonfly](https://www.cncf.io/wp-content/uploads/2023/09/image8-18.png)
+
+Create dragonfly cluster B record successfully.
+
+![Screenshot showing Cluster page on Dragonfly](https://www.cncf.io/wp-content/uploads/2023/09/image5-28.png)
+
+### Use scopes to distinguish different dragonfly clusters
+
+The dragonfly cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope. The scopes of the dragonfly cluster are configured when the console is created and updated. The scopes of the peer are configured in peer YAML config, the fields are host.idc, host.location and host.advertiseIP, refer to [dfdaemon config](https://d7y.io/docs/next/reference/configuration/dfdaemon).
+
+If the peer scopes match the dragonfly cluster scopes, then the peer will use the dragonfly cluster’s scheduler and seed peer first, and if there is no matching dragonfly cluster then use the default dragonfly cluster.
+
+Location: The dragonfly cluster needs to serve all peers in the location. When the location in the peer configuration matches the location in the dragonfly cluster, the peer will preferentially use the scheduler and the seed peer of the dragonfly cluster. It separated by “|”, for example “area|country|province|city”.
+
+IDC: The dragonfly cluster needs to serve all peers in the IDC. When the IDC in the peer configuration matches the IDC in the dragonfly cluster, the peer will preferentially use the scheduler and the seed peer of the dragonfly cluster. IDC has higher priority than location in the scopes.
+
+CIDRs: The dragonfly cluster needs to serve all peers in the CIDRs. The advertise IP will be reported in the peer configuration when the peer is started, and if the advertise IP is empty in the peer configuration, peer will automatically get expose IP as advertise IP. When advertise IP of the peer matches the CIDRs in dragonfly cluster, the peer will preferentially use the scheduler and the seed peer of the dragonfly cluster. CIDRs has higher priority than IDC in the scopes.
+
+### Create dragonfly cluster B based on helm charts
+
+Create charts configuration with cluster information in the manager console.
+
+![Screenshot showing Cluster-2 page on Dragonfly](https://www.cncf.io/wp-content/uploads/2023/09/image14-3.png)
+
+- Scheduler.config.manager.schedulerClusterID using the Scheduler cluster ID from cluster-2 information in the manager console.
+- Scheduler.config.manager.addr is address of the manager GRPC server.
+- seedPeer.config.scheduler.manager.seedPeer.clusterID using the Seed peer cluster ID from cluster-2 information in the manager console.
+- seedPeer.config.scheduler.manager.netAddrs\[0\].addr is address of the manager GRPC server.
+- dfdaemon.config.host.idc using the IDC from cluster-2 information in the manager console.
+- dfdaemon.config.scheduler.manager.netAddrs\[0\].addr is address of the manager GRPC server.
+- externalManager.host is host of the manager GRPC server.
+- externalRedis.addrs\[0\] is address of the redis.
+
+Create dragonfly cluster B charts configuration file charts-config-cluster-b.yaml, configuration content is as follows:
+
+```yaml
+containerRuntime:
+  containerd:
+    enable: true
+    injectConfigPath: true
+    registries:
+      - 'https://ghcr.io'
+scheduler:
+  image: dragonflyoss/scheduler
+  tag: latest
+  nodeSelector:
+    cluster: b
+  replicas: 1
+  config:
+    manager:
+      addr: dragonfly-manager.cluster-a.svc.cluster.local:65003
+      schedulerClusterID: 2
+seedPeer:
+  image: dragonflyoss/dfdaemon
+  tag: latest
+  nodeSelector:
+    cluster: b
+  replicas: 1
+  config:
+    scheduler:
+      manager:
+        netAddrs:
+          - type: tcp
+            addr: dragonfly-manager.cluster-a.svc.cluster.local:65003
+        seedPeer:
+          enable: true
+          clusterID: 2
+dfdaemon:
+  image: dragonflyoss/dfdaemon
+  tag: latest
+  nodeSelector:
+    cluster: b
+  config:
+    host:
+      idc: cluster-2
+    scheduler:
+      manager:
+        netAddrs:
+          - type: tcp
+            addr: dragonfly-manager.cluster-a.svc.cluster.local:65003
+manager:
+  enable: false
+externalManager:
+  enable: true
+  host: dragonfly-manager.cluster-a.svc.cluster.local
+  restPort: 8080
+  grpcPort: 65003
+redis:
+  enable: false
+externalRedis:
+  addrs:
+    - dragonfly-redis-master.cluster-a.svc.cluster.local:6379
+  password: dragonfly
+mysql:
+  enable: false
+jaeger:
+  enable: true
+```
+
+Create dragonfly cluster B using the configuration file:
+
+```bash
+$ helm install --wait --create-namespace --namespace cluster-b dragonfly dragonfly/dragonfly -f charts-config-cluster-b.yaml
+NAME: dragonfly
+LAST DEPLOYED: Mon Aug  7 22:13:51 2023
+NAMESPACE: cluster-b
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+1. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace cluster-b -l "app=dragonfly,release=dragonfly,component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace cluster-b $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace cluster-b port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+
+2. Get the dfdaemon port by running these commands:
+  export DFDAEMON_POD_NAME=$(kubectl get pods --namespace cluster-b -l "app=dragonfly,release=dragonfly,component=dfdaemon" -o jsonpath={.items[0].metadata.name})
+  export DFDAEMON_CONTAINER_PORT=$(kubectl get pod --namespace cluster-b $DFDAEMON_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  You can use $DFDAEMON_CONTAINER_PORT as a proxy port in Node.
+
+3. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+
+4. Get Jaeger query URL by running these commands:
+  export JAEGER_QUERY_PORT=$(kubectl --namespace cluster-b get services dragonfly-jaeger-query -o jsonpath="{.spec.ports[0].port}")
+  kubectl --namespace cluster-b port-forward service/dragonfly-jaeger-query 16686:$JAEGER_QUERY_PORT
+  echo "Visit http://127.0.0.1:16686/search?limit=20&lookback=1h&maxDuration&minDuration&service=dragonfly to query download events"
+```
+
+Check that dragonfly cluster B is deployed successfully:
+
+```bash
+$ kubectl get po -n cluster-b
+NAME                                READY   STATUS    RESTARTS   AGE
+dragonfly-dfdaemon-q8bsg            1/1     Running   0          67s
+dragonfly-dfdaemon-tsqls            1/1     Running   0          67s
+dragonfly-jaeger-84dbfd5b56-rg5dv   1/1     Running   0          67s
+dragonfly-scheduler-0               1/1     Running   0          67s
+dragonfly-seed-peer-0               1/1     Running   0          67s
+```
+
+Create dragonfly cluster B successfully.
+
+![Screenshot showing Cluster-2 page on Dragonfly](https://www.cncf.io/wp-content/uploads/2023/09/image13-5.png)
+
+## Using dragonfly to distribute images for multi-cluster kubernetes
+
+### Containerd pull image back-to-source for the first time through dragonfly in cluster A
+
+Pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5 image in kind-worker node:
+
+```bash
+docker exec -i kind-worker /usr/local/bin/crictl pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5
+```
+
+Expose jaeger’s port 16686:
+
+```bash
+kubectl --namespace cluster-a port-forward service/dragonfly-jaeger-query 16686:16686
+```
+
+Visit the Jaeger page in `http://127.0.0.1:16686/search`, Search for tracing with Tags `http.url="/v2/dragonflyoss/dragonfly2/scheduler/blobs/sha256:82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399?ns=ghcr.io"`:
+
+![Screenshot showing Jaeger page (dragonfly-dfget)](https://www.cncf.io/wp-content/uploads/2023/09/image1-58.png)
+
+Tracing details:
+
+![Screenshot showing dragonfly-dfget:proxy tracing details on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image7-18.png)
+
+When pull image back-to-source for the first time through dragonfly, peer uses cluster-a’s scheduler and seed peer. It takes 1.47s to download the 82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399 layer.
+
+### Containerd pull image hits the cache of remote peer in cluster A
+
+Pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5 image in kind-worker2 node:
+
+```bash
+docker exec -i kind-worker2 /usr/local/bin/crictl pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5
+```
+
+Expose jaeger’s port 16686:
+
+```bash
+kubectl --namespace cluster-a port-forward service/dragonfly-jaeger-query 16686:16686
+```
+
+Visit the Jaeger page in [http://127.0.0.1:16686/search](http://127.0.0.1:16686/search), Search for tracing with Tags `http.url="/v2/dragonflyoss/dragonfly2/scheduler/blobs/sha256:82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399?ns=ghcr.io"`:
+
+![Screenshot showing dragonfly-dfget on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image2-55.png)
+
+Tracing details:
+
+![Screenshot showing dragonfly-dfget Tracing Details on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image9-15.png)
+
+When pull image hits cache of remote peer, peer uses cluster-a’s scheduler and seed peer. It takes 37.48ms to download the 82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399 layer.
+
+### Containerd pull image back-to-source for the first time through dragonfly in cluster B
+
+Pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5 image in kind-worker3 node:
+
+```bash
+docker exec -i kind-worker3 /usr/local/bin/crictl pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5
+```
+
+Expose jaeger’s port 16686:
+
+```bash
+kubectl --namespace cluster-b port-forward service/dragonfly-jaeger-query 16686:16686
+```
+
+Visit the Jaeger page in [http://127.0.0.1:16686/search](http://127.0.0.1:16686/search), Search for tracing with Tags http.url=”/v2/dragonflyoss/dragonfly2/scheduler/blobs/sha256:82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399?ns=ghcr.io”:
+
+![Screenshot showing dragonfly-dfget on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image3-42.png)
+
+Tracing details:
+
+![Screenshot showing dragonfly-dfget Tracing Details on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image12-6.png)
+
+When pull image back-to-source for the first time through dragonfly, peer uses cluster-b’s scheduler and seed peer. It takes 4.97s to download the `82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399` layer.
+
+### Containerd pull image hits the cache of remote peer in cluster B
+
+Pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5 image in kind-worker4 node:
+
+```bash
+docker exec -i kind-worker4 /usr/local/bin/crictl pull ghcr.io/dragonflyoss/dragonfly2/scheduler:v2.0.5
+```
+
+Expose jaeger’s port 16686:
+
+```bash
+kubectl --namespace cluster-b port-forward service/dragonfly-jaeger-query 16686:16686
+```
+
+Visit the Jaeger page in [http://127.0.0.1:16686/search](http://127.0.0.1:16686/search), Search for tracing with Tags ```http.url="/v2/dragonflyoss/dragonfly2/scheduler/blobs/sha256:82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399?ns=ghcr.io"```:
+
+![Screenshot showing dragonfly-dfget on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image6-19.png)
+
+Tracing details:
+
+![Screenshot showing dragonfly-dfget Tracing Details on Jaeger UI](https://www.cncf.io/wp-content/uploads/2023/09/image15-6.png)
+
+When pull image hits cache of remote peer, peer uses cluster-b’s scheduler and seed peer. It takes 14.53ms to download the `82cbeb56bf8065dfb9ff5a0c6ea212ab3a32f413a137675df59d496e68eaf399` layer.
+
+## Links
+
+Dragonfly Website: [https://d7y.io/](https://d7y.io/)
+
+Dragonfly Github Repo: [https://github.com/dragonflyoss/Dragonfly2](https://github.com/dragonflyoss/Dragonfly2)
+
+Dragonfly Slack Channel: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
+
+Dragonfly Discussion Group: [dragonfly-discuss@googlegroups.com](mailto:dragonfly-discuss@googlegroups.com)
+
+Dragonfly Twitter: [@dragonfly\_oss](https://twitter.com/dragonfly_oss)
+
+Nydus Website: [https://nydus.dev/](https://nydus.dev/)
+
+Nydus Github Repo: [https://github.com/dragonflyoss/image-service](https://github.com/dragonflyoss/image-service)

--- a/blog/2023-11-16-hugging-face-accelerates-distribution-of-models-and-datasets-based-on-dragonfly/index.md
+++ b/blog/2023-11-16-hugging-face-accelerates-distribution-of-models-and-datasets-based-on-dragonfly/index.md
@@ -1,0 +1,373 @@
+---
+title:  Hugging Face accelerates distribution of models and datasets based on Dragonfly
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+
+<!-- Posted on November 16, 2023 -->
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/11/16/hugging-face-accelerates-distribution-of-models-and-datasets-based-on-dragonfly/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+<!-- [![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg)](https://www.cncf.io/projects/dragonfly "Go to Dragonfly") -->
+
+<!-- _Project post by Gaius, Dragonfly Maintainer_ -->
+
+This document will help you experience how to use dragonfly with hugging face. During the downloading of datasets or models, the file size is large and there are many services downloading the files at the same time. The bandwidth of the storage will reach the limit and the download will be slow.
+
+![Diagram flow showing Hugging Face Hub flow from Cluster A and Cluster B](https://www.cncf.io/wp-content/uploads/2023/11/image-36.png)
+
+Dragonfly can be used to eliminate the bandwidth limit of the storage through P2P technology, thereby accelerating file downloading.
+
+![Diagram flow showing Hugging Face Hub flow from Cluster A and Cluster B](https://www.cncf.io/wp-content/uploads/2023/11/image-37.jpg)
+
+## Prerequisites
+
+Notice: [Kind](https://kind.sigs.k8s.io/) is recommended if no kubernetes cluster is available for testing.
+
+## Install dragonfly
+
+For detailed installation documentation based on kubernetes cluster, please refer to [quick-start-kubernetes](https://d7y.io/docs/next/getting-started/quick-start/kubernetes/).
+
+### Setup kubernetes cluster
+
+Create kind multi-node cluster configuration file kind-config.yaml, configuration content is as follows:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+    extraPortMappings:
+      - containerPort: 30950
+        hostPort: 65001
+  - role: worker
+```
+
+Create a kind multi-node cluster using the configuration file:
+
+```bash
+kind create cluster --config kind-config.yaml
+```
+
+Switch the context of kubectl to kind cluster:
+
+```bash
+kubectl config use-context kind-kind
+```
+
+### Kind loads dragonfly image
+
+Pull dragonfly latest images:
+
+```bash
+docker pull dragonflyoss/scheduler:latestdocker pull dragonflyoss/manager:latestdocker pull dragonflyoss/dfdaemon:latest
+```
+
+Kind cluster loads dragonfly latest images:
+
+```bash
+kind load docker-image dragonflyoss/scheduler:latestkind load docker-image dragonflyoss/manager:latestkind load docker-image dragonflyoss/dfdaemon:latest
+```
+
+### Create dragonfly cluster based on helm charts
+
+Create helm charts configuration file charts-config.yaml and set dfdaemon.config.proxy.registryMirror.url to the address of the Hugging Face Hub’s LFS server, configuration content is as follows:
+
+```yaml
+scheduler:
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+
+seedPeer:
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+
+dfdaemon:
+  metrics:
+    enable: true
+  hostNetwork: true
+  config:
+    verbose: true
+    pprofPort: 18066
+    proxy:
+      defaultFilter: 'Expires&Key-Pair-Id&Policy&Signature'
+      security:
+        insecure: true
+      tcpListen:
+        listen: 0.0.0.0
+        port: 65001
+      registryMirror:
+        # When enable, using header "X-Dragonfly-Registry" for remote instead of url.
+        dynamic: true
+        # URL for the registry mirror.
+        url: https://cdn-lfs.huggingface.co
+        # Whether to ignore https certificate errors.
+        insecure: true
+        # Optional certificates if the remote server uses self-signed certificates.
+        certs: []
+        # Whether to request the remote registry directly.
+        direct: false
+        # Whether to use proxies to decide if dragonfly should be used.
+        useProxies: true
+      proxies:
+        - regx: repos.*
+          useHTTPS: true
+
+manager:
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+```
+
+Create a dragonfly cluster using the configuration file:
+
+```bash
+$ helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+$ helm install --wait --create-namespace --namespace dragonfly-system dragonfly dragonfly/dragonfly -f charts-config.yaml
+NAME: dragonfly
+LAST DEPLOYED: Wed Oct 19 04:23:22 2022
+NAMESPACE: dragonfly-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+1. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace dragonfly-system $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace dragonfly-system port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+2. Get the dfdaemon port by running these commands:
+  export DFDAEMON_POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=dfdaemon" -o jsonpath={.items[0].metadata.name})
+  export DFDAEMON_CONTAINER_PORT=$(kubectl get pod --namespace dragonfly-system $DFDAEMON_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  You can use $DFDAEMON_CONTAINER_PORT as a proxy port in Node.
+3. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+```
+
+Check that dragonfly is deployed successfully:
+
+```bash
+$ kubectl get po -n dragonfly-system
+NAME                                 READY   STATUS    RESTARTS       AGE
+dragonfly-dfdaemon-rhnr6             1/1     Running   4 (101s ago)   3m27s
+dragonfly-dfdaemon-s6sv5             1/1     Running   5 (111s ago)   3m27s
+dragonfly-manager-67f97d7986-8dgn8   1/1     Running   0              3m27s
+dragonfly-mysql-0                    1/1     Running   0              3m27s
+dragonfly-redis-master-0             1/1     Running   0              3m27s
+dragonfly-redis-replicas-0           1/1     Running   1 (115s ago)   3m27s
+dragonfly-redis-replicas-1           1/1     Running   0              95s
+dragonfly-redis-replicas-2           1/1     Running   0              70s
+dragonfly-scheduler-0                1/1     Running   0              3m27s
+dragonfly-seed-peer-0                1/1     Running   2 (95s ago)    3m27s
+```
+
+Create peer service configuration file peer-service-config.yaml, configuration content is as follows:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: peer
+  namespace: dragonfly-system
+spec:
+  type: NodePort
+  ports:
+    - name: http-65001
+      nodePort: 30950
+      port: 65001
+  selector:
+    app: dragonfly
+    component: dfdaemon
+    release: dragonfly
+```
+
+Create a peer service using the configuration file:
+
+```bash
+kubectl apply -f peer-service-config.yaml
+```
+
+## Use Hub Python Library to download files and distribute traffic through Draognfly
+
+Any API in the [Hub Python Library](https://huggingface.co/docs/huggingface_hub/index) that uses Requests library for downloading files can distribute the download traffic in the P2P network by setting DragonflyAdapter to the requests Session.
+
+### Download a single file with Dragonfly
+
+A single file can be downloaded using the [hf\_hub\_download](https://huggingface.co/docs/huggingface_hub/v0.17.1/en/package_reference/file_download#huggingface_hub.hf_hub_download), distribute traffic through the Dragonfly peer.
+
+Create hf\_hub\_download\_dragonfly.py file. Use DragonflyAdapter to forward the file download request of the LFS protocol to Dragonfly HTTP proxy, so that it can use the P2P network to distribute file, content is as follows:
+
+```python
+import requests
+from requests.adapters import HTTPAdapter
+from urllib.parse import urlparse
+from huggingface_hub import hf_hub_download
+from huggingface_hub import configure_http_backend
+
+class DragonflyAdapter(HTTPAdapter):
+  def get_connection(self, url, proxies=None):
+    # Change the schema of the LFS request to download large files from https:// to http://,
+    # so that Dragonfly HTTP proxy can be used.
+    if url.startswith('https://cdn-lfs.huggingface.co'):
+      url = url.replace('https://', 'http://')
+    return super().get_connection(url, proxies)
+
+  def add_headers(self, request, kwargs):
+    super().add_headers(request, kwargs)
+    # If there are multiple different LFS repositories, you can override the
+    # default repository address by adding X-Dragonfly-Registry header.
+    if request.url.find('example.com') != -1:
+      request.headers["X-Dragonfly-Registry"] = 'https://example.com'
+
+# Create a factory function that returns a new Session.
+def backend_factory() -> requests.Session:
+  session = requests.Session()
+  session.mount('http://', DragonflyAdapter())
+  session.mount('https://', DragonflyAdapter())
+  session.proxies = {'http': 'http://127.0.0.1:65001'}
+  return session
+
+# Set it as the default session factory
+configure_http_backend(backend_factory=backend_factory)
+
+hf_hub_download(repo_id="tiiuae/falcon-rw-1b", filename="pytorch_model.bin")
+```
+
+Download a single file of th LFS protocol with Dragonfly:
+
+```bash
+$ python3 hf_hub_download_dragonfly.py
+(…)YkNX13a46FCg__&Key-Pair-Id=KVTP0A1DKRTAX: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.62G/2.62G [00:52<00:00, 49.8MB/s]
+```
+
+#### Verify a single file download with Dragonfly
+
+Execute the command:
+
+```bash
+# find podskubectl -n dragonfly-system get pod -l component=dfdaemon# find logspod_name=dfdaemon-xxxxxkubectl -n dragonfly-system exec -it ${pod_name} -- grep "peer task done" /var/log/dragonfly/daemon/core.log
+```
+
+Example output:
+
+```bash
+peer task done, cost: 28349ms   {"peer": "89.116.64.101-77008-a95a6918-a52b-47f5-9b18-cec6ada03daf", "task": "2fe93348699e07ab67823170925f6be579a3fbc803ff3d33bf9278a60b08d901", "component": "PeerTask", "trace": "b34ed802b7afc0f4acd94b2cedf3fa2a"}
+```
+
+### Download a snapshot of the repo with Dragonfly
+
+A snapshot of the repo can be downloaded using the [snapshot\_download](https://huggingface.co/docs/huggingface_hub/v0.17.1/en/package_reference/file_download#huggingface_hub.snapshot_download), distribute traffic through the Dragonfly peer.
+
+Create snapshot\_download\_dragonfly.py file. Use DragonflyAdapter to forward the file download request of the LFS protocol to Dragonfly HTTP proxy, so that it can use the P2P network to distribute file. Only the files of the LFS protocol will be distributed through the Dragonfly P2P network. content is as follows:
+
+```python
+import requests
+from requests.adapters import HTTPAdapter
+from urllib.parse import urlparse
+from huggingface_hub import snapshot_download
+from huggingface_hub import configure_http_backend
+
+class DragonflyAdapter(HTTPAdapter):
+  def get_connection(self, url, proxies=None):
+    # Change the schema of the LFS request to download large files from https:// to http://,
+    # so that Dragonfly HTTP proxy can be used.
+    if url.startswith('https://cdn-lfs.huggingface.co'):
+      url = url.replace('https://', 'http://')
+    return super().get_connection(url, proxies)
+
+  def add_headers(self, request, kwargs):
+    super().add_headers(request, kwargs)
+    # If there are multiple different LFS repositories, you can override the
+    # default repository address by adding X-Dragonfly-Registry header.
+    if request.url.find('example.com') != -1:
+      request.headers["X-Dragonfly-Registry"] = 'https://example.com'
+
+# Create a factory function that returns a new Session.
+def backend_factory() -> requests.Session:
+  session = requests.Session()
+  session.mount('http://', DragonflyAdapter())
+  session.mount('https://', DragonflyAdapter())
+  session.proxies = {'http': 'http://127.0.0.1:65001'}
+  return session
+
+# Set it as the default session factory
+configure_http_backend(backend_factory=backend_factory)
+
+snapshot_download(repo_id="tiiuae/falcon-rw-1b")
+```
+
+Download a snapshot of the repo with Dragonfly:
+
+```bash
+$ python3 snapshot_download_dragonfly.py
+(…)03165eb22f0a867d4e6a64d34fce19/README.md: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.60k/7.60k [00:00<00:00, 374kB/s]
+(…)7d4e6a64d34fce19/configuration_falcon.py: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6.70k/6.70k [00:00<00:00, 762kB/s]
+(…)f0a867d4e6a64d34fce19/modeling_falcon.py: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 56.9k/56.9k [00:00<00:00, 5.35MB/s]
+(…)3165eb22f0a867d4e6a64d34fce19/merges.txt: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 456k/456k [00:00<00:00, 9.07MB/s]
+(…)867d4e6a64d34fce19/tokenizer_config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 234/234 [00:00<00:00, 106kB/s]
+(…)eb22f0a867d4e6a64d34fce19/tokenizer.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.11M/2.11M [00:00<00:00, 27.7MB/s]
+(…)3165eb22f0a867d4e6a64d34fce19/vocab.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 798k/798k [00:00<00:00, 19.7MB/s]
+(…)7d4e6a64d34fce19/special_tokens_map.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 99.0/99.0 [00:00<00:00, 45.3kB/s]
+(…)67d4e6a64d34fce19/generation_config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 115/115 [00:00<00:00, 5.02kB/s]
+(…)165eb22f0a867d4e6a64d34fce19/config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.05k/1.05k [00:00<00:00, 75.9kB/s]
+(…)eb22f0a867d4e6a64d34fce19/.gitattributes: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.48k/1.48k [00:00<00:00, 171kB/s]
+(…)t-oSSW23tawg__&Key-Pair-Id=KVTP0A1DKRTAX: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.62G/2.62G [00:50<00:00, 52.1MB/s]
+Fetching 12 files: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 12/12 [00:50<00:00,  4.23s/it]
+```
+
+#### Verify a snapshot of the repo download with Dragonfly
+
+Execute the command:
+
+```bash
+# find podskubectl -n dragonfly-system get pod -l component=dfdaemon# find logspod_name=dfdaemon-xxxxxkubectl -n dragonfly-system exec -it ${pod_name} -- grep "peer task done" /var/log/dragonfly/daemon/core.log
+```
+
+Example output:
+
+```bash
+peer task done, cost: 28349ms   {"peer": "89.116.64.101-77008-a95a6918-a52b-47f5-9b18-cec6ada03daf", "task": "2fe93348699e07ab67823170925f6be579a3fbc803ff3d33bf9278a60b08d901", "component": "PeerTask", "trace": "b34ed802b7afc0f4acd94b2cedf3fa2a"}
+```
+
+## Performance testing
+
+Test the performance of single-machine file download by hf\_hub\_download API after the integration of Hugging Face Python Library and Dragonfly P2P. Due to the influence of the network environment of the machine itself, the actual download time is not important, but the ratio of the increase in the download time in different scenarios is very important.
+
+![Bar chart showing performance testing result](https://www.cncf.io/wp-content/uploads/2023/11/image-37.png)
+
+- Hugging Face Python Library: Use hf\_hub\_download API to download models directly.
+- Hugging Face Python Library & Dragonfly Cold Boot: Use hf\_hub\_download API to download models via Dragonfly P2P network and no cache hits.
+- Hit Dragonfly Remote Peer Cache: Use hf\_hub\_download API to download models via Dragonfly P2P network and hit the remote peer cache.
+- Hit Dragonfly Local Peer Cache: Use hf\_hub\_download API to download models via Dragonfly P2P network and hit the local peer cache.
+- Hit Hugging Face Cache: Use hf\_hub\_download API to download models via Dragonfly P2P network and hit the Hugging Face local cache.
+
+Test results show Hugging Face Python Library and Dragonfly P2P integration. It can effectively reduce the file download time. Note that this test was a single-machine test, which means that in the case of cache hits, the performance limitation is on the disk. If Dragonfly is deployed on multiple machines for P2P download, the models download speed will be faster.
+
+## Links
+
+### Dragonfly community
+
+- Website: [https://d7y.io/](https://d7y.io/)
+- Github Repo: [https://github.com/dragonflyoss/Dragonfly2](https://github.com/dragonflyoss/Dragonfly2)
+- Slack Channel: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
+- Discussion Group: [dragonfly-discuss@googlegroups.com](mailto:dragonfly-discuss@googlegroups.com)
+- Twitter: [@dragonfly\_oss](https://twitter.com/dragonfly_oss)
+
+### Hugging Face
+
+- Website: [https://huggingface.co/](https://huggingface.co/)
+- Github Repo: [https://github.com/huggingface/huggingface\_hub](https://github.com/huggingface/huggingface_hub)
+- Document: [https://huggingface.co/docs](https://huggingface.co/docs)
+- Hub Python Library: [https://huggingface.co/docs/huggingface\_hub/index](https://huggingface.co/docs/huggingface_hub/index)

--- a/blog/2023-12-06-torchserve-accelerates-the-distribution-of-models-based-on-dragonfly/index.md
+++ b/blog/2023-12-06-torchserve-accelerates-the-distribution-of-models-based-on-dragonfly/index.md
@@ -1,0 +1,679 @@
+---
+title: TorchServe accelerates the distribution of models based on Dragonfly
+tags: [dragonfly, container image, OCI, nydus, nydus-snapshotter, containerd]
+hide_table_of_contents: false
+---
+
+<!-- Posted on December 6, 2023 by Congwang Li -->
+
+[CNCF projects highlighted in this post](https://www.cncf.io/blog/2023/12/06/torchserve-accelerates-the-distribution-of-models-based-on-dragonfly/), and migrated by [mingcheng](https://github.com/mingcheng).
+
+ <!-- [![Dragonfly logo](https://landscape.cncf.io/logos/60b07adb6812ca92688c7a1c33b13001022b0dd73cd3b8e64a415e4f003cde16.svg)](https://www.cncf.io/projects/dragonfly "Go to Dragonfly")[![Kubernetes logo](https://landscape.cncf.io/logos/e0303fdc381c96c1b4461ad1a2437c8f050cfb856fcb8710c9104367ca60f316.svg)](https://www.cncf.io/projects/kubernetes "Go to Kubernetes") -->
+
+This document will help you experience how to use dragonfly with [TorchServe](https://github.com/pytorch/serve). During the downloading of models, the file size is large and there are many services downloading the files at the same time. The bandwidth of the storage will reach the limit and the download will be slow.
+
+![Diagram flow showing Model Registry flow from Cluster A and Cluster B](https://www.cncf.io/wp-content/uploads/2023/12/image-5.png)
+
+Dragonfly can be used to eliminate the bandwidth limit of the storage through P2P technology, thereby accelerating file downloading.
+
+![Diagram flow showing Model Registry flow from Cluster A and Cluster B](https://www.cncf.io/wp-content/uploads/2023/12/image-7.png)
+
+## Architecture
+
+![Dragonfly Endpoint architecture](https://www.cncf.io/wp-content/uploads/2023/12/dragonfly1.png)
+
+[Dragonfly Endpoint](https://github.com/dragonflyoss/dragonfly-endpoint) plugin forwards TorchServe download model requests to the Dragonfly P2P network.
+
+![Dragonfly Endpoint architecture](https://www.cncf.io/wp-content/uploads/2023/12/dragonfly2.png)
+
+The models download steps:
+
+1. TorchServe sends a model download request and the request is forwarded to the Dragonfly Peer.
+2. The Dragonfly Peer registers tasks with the Dragonfly Scheduler.
+3. Return the candidate parents to Dragonfly Peer.
+4. Dragonfly Peer downloads model from candidate parents.
+5. After downloading the model, TorchServe will register the model.
+
+## Installation
+
+By integrating Dragonfly Endpoint into TorchServe, download traffic through Dragonfly to pull models stored in S3, OSS, GCS, and ABS, and register models in TorchServe. The Dragonfly Endpoint plugin is in the [dragonfly-endpoint](https://github.com/dragonflyoss/dragonfly-endpoint) repository.
+
+## Prerequisites
+
+| Name               | Version | Document                                         |
+| ------------------ | ------- | ------------------------------------------------ |
+| Kubernetes cluster | 1.20+   | [kubernetes.io](https://kubernetes.io/)          |
+| Helm               | 3.8.0+  | [helm.sh](https://helm.sh/)                      |
+| TorchServe         | 0.4.0+  | [pytorch.org/serve/](https://pytorch.org/serve/) |
+
+Notice: [Kind](https://kind.sigs.k8s.io/) is recommended if no kubernetes cluster is available for testing.
+
+## Dragonfly Kubernetes Cluster Setup
+
+For detailed installation documentation, please refer to  [quick-start-kubernetes](https://d7y.io/zh/docs/getting-started/quick-start/kubernetes/).
+
+### Prepare Kubernetes Cluster
+
+Create kind multi-node cluster configuration file kind-config.yaml, configuration content is as follows:
+
+```bash
+kind: ClusterapiVersion: kind.x-k8s.io/v1alpha4nodes:  - role: control-plane  - role: worker  - role: worker
+```
+
+Create a kind multi-node cluster using the configuration file:
+
+```bash
+kind create cluster --config kind-config.yaml
+```
+
+Switch the context of kubectl to kind cluster:
+
+```bash
+kubectl config use-context kind-kind
+```
+
+### Kind loads dragonfly image
+
+Pull dragonfly latest images:
+
+```bash
+docker pull dragonflyoss/scheduler:latestdocker pull dragonflyoss/manager:latestdocker pull dragonflyoss/dfdaemon:latest
+```
+
+Kind cluster loads dragonfly latest images:
+
+```bash
+kind load docker-image dragonflyoss/scheduler:latestkind load docker-image dragonflyoss/manager:latestkind load docker-image dragonflyoss/dfdaemon:latest
+```
+
+### Create dragonfly cluster based on helm charts
+
+Create helm charts configuration file charts-config.yaml and set dfdaemon.config.agents.regx to match the download path of the object storage, configuration content is as follows:
+
+```yaml
+scheduler:
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+
+seedPeer:
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+
+dfdaemon:
+  hostNetwork: true
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+    proxy:
+      defaultFilter: "Expires&Signature&ns"
+      security:
+        insecure: true
+        cacert: ""
+        cert: ""
+        key: ""
+      tcpListen:
+        namespace: ""
+        port: 65001
+      registryMirror:
+        url: https://index.docker.io
+        insecure: true
+        certs: []
+        direct: false
+      proxies:
+      - regx: blobs/sha256.*
+      - regx: .*amazonaws.*
+
+manager:
+  replicas: 1
+  metrics:
+    enable: true
+  config:
+    verbose: true
+    pprofPort: 18066
+
+jaeger:
+  enable: true
+```
+
+Create a dragonfly cluster using the configuration file:
+
+```bash
+$ helm repo add dragonfly https://dragonflyoss.github.io/helm-charts/
+$ helm install --wait --create-namespace --namespace dragonfly-system dragonfly dragonfly/dragonfly -f charts-config.yaml
+LAST DEPLOYED: Mon Sep  4 10:24:55 2023
+NAMESPACE: dragonfly-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+1. Get the scheduler address by running these commands:
+  export SCHEDULER_POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=scheduler" -o jsonpath={.items[0].metadata.name})
+  export SCHEDULER_CONTAINER_PORT=$(kubectl get pod --namespace dragonfly-system $SCHEDULER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace dragonfly-system port-forward $SCHEDULER_POD_NAME 8002:$SCHEDULER_CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8002 to use your scheduler"
+2. Get the dfdaemon port by running these commands:
+  export DFDAEMON_POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=dfdaemon" -o jsonpath={.items[0].metadata.name})
+  export DFDAEMON_CONTAINER_PORT=$(kubectl get pod --namespace dragonfly-system $DFDAEMON_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  You can use $DFDAEMON_CONTAINER_PORT as a proxy port in Node.
+3. Configure runtime to use dragonfly:
+  https://d7y.io/docs/getting-started/quick-start/kubernetes/
+4. Get Jaeger query URL by running these commands:
+  export JAEGER_QUERY_PORT=$(kubectl --namespace dragonfly-system get services dragonfly-jaeger-query -o jsonpath="{.spec.ports[0].port}")
+  kubectl --namespace dragonfly-system port-forward service/dragonfly-jaeger-query 16686:$JAEGER_QUERY_PORT
+  echo "Visit http://127.0.0.1:16686/search?limit=20&lookback=1h&maxDuration&minDuration&service=dragonfly to query download events"
+```
+
+Check that dragonfly is deployed successfully:
+
+```bash
+$ kubectl get po -n dragonfly-system
+NAME                                 READY   STATUS    RESTARTS      AGE
+dragonfly-dfdaemon-7r2cn             1/1     Running   0          3m31s
+dragonfly-dfdaemon-fktl4             1/1     Running   0          3m31s
+dragonfly-jaeger-c7947b579-2xk44     1/1     Running   0          3m31s
+dragonfly-manager-5d4f444c6c-wq8d8   1/1     Running   0          3m31s
+dragonfly-mysql-0                    1/1     Running   0          3m31s
+dragonfly-redis-master-0             1/1     Running   0          3m31s
+dragonfly-redis-replicas-0           1/1     Running   0          3m31s
+dragonfly-redis-replicas-1           1/1     Running   0          3m5s
+dragonfly-redis-replicas-2           1/1     Running   0          2m44s
+dragonfly-scheduler-0                1/1     Running   0          3m31s
+dragonfly-seed-peer-0                1/1     Running   0          3m31s
+```
+
+### Expose the Proxy service port
+
+Create the dfstore.yaml configuration to expose the port on which the Dragonfly Peer’s HTTP proxy listens. The default port is 65001 and settargetPort to 65001.
+
+```yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: dfstore
+spec:
+  selector:
+    app: dragonfly
+    component: dfdaemon
+    release: dragonfly
+  ports:
+  - protocol: TCP
+    port: 65001
+    targetPort: 65001
+  type: NodePort
+```
+
+Create service:
+
+```bash
+kubectl --namespace dragonfly-system apply -f dfstore.yaml
+```
+
+Forward request to Dragonfly Peer’s HTTP proxy:
+
+```bash
+kubectl --namespace dragonfly-system port-forward service/dfstore 65001:65001
+```
+
+## Install Dragonfly Endpoint plugin
+
+### Set environment variables for Dragonfly Endpoint configuration
+
+Create config.json configuration，and set DRAGONFLY\_ENDPOINT\_CONFIG environment variable for config.json file path.
+
+```bash
+export DRAGONFLY_ENDPOINT_CONFIG=/etc/dragonfly-endpoint/config.json
+```
+
+The default configuration path is:
+
+- linux: /etc/dragonfly-endpoint/config.json
+- darwin: ~/.dragonfly-endpoint/config.json
+
+### Dragonfly Endpoint configuration
+
+Create the config.json configuration to configure the Dragonfly Endpoint for S3, the configuration is as follows:
+
+```json
+{
+  "addr": "http://127.0.0.1:65001",
+  "header": {},
+  "filter": [
+    "X-Amz-Algorithm",
+    "X-Amz-Credential",
+    "X-Amz-Date",
+    "X-Amz-Expires",
+    "X-Amz-SignedHeaders",
+    "X-Amz-Signature"
+  ],
+  "object_storage": {
+    "type": "s3",
+    "bucket_name": "your_s3_bucket_name",
+    "region": "your_s3_region",
+    "access_key": "your_s3_access_key",
+    "secret_key": "your_s3_secret_key"
+  }
+}
+```
+
+In the filter of the configuration, set different values when using different object storage:
+
+In the filter of the configuration, set different values when using different object storage:
+
+| Type | Value                                                                                                      |
+| ---- | ---------------------------------------------------------------------------------------------------------- |
+| OSS  | "Expires&Signature&ns"                                                                                     |
+| S3   | "X-Amz-Algorithm&X-Amz-Credential&X-Amz-Date&X-Amz-Expires&X-Amz-SignedHeaders&X-Amz-Signature"            |
+| OBS  | "X-Amz-Algorithm&X-Amz-Credential&X-Amz-Date&X-Obs-Date&X-Amz-Expires&X-Amz-SignedHeaders&X-Amz-Signature" |
+
+#### Object storage configuration
+
+In addition to S3, Dragonfly Endpoint plugin also supports OSS, GCS and ABS. Different object storage configurations are as follows:
+
+OSS(Object Storage Service)
+
+```json
+{
+  "addr": "http://127.0.0.1:65001",
+  "header": {},
+  "filter": ["Expires", "Signature"],
+  "object_storage": {
+    "type": "oss",
+    "bucket_name": "your_oss_bucket_name",
+    "endpoint": "your_oss_endpoint",
+    "access_key_id": "your_oss_access_key_id",
+    "access_key_secret": "your_oss_access_key_secret"
+  }
+}
+```
+
+GCS(Google Cloud Storage)
+
+```json
+{
+  "addr": "http://127.0.0.1:65001",
+  "header": {},
+  "object_storage": {
+    "type": "gcs",
+    "bucket_name": "your_gcs_bucket_name",
+    "project_id": "your_gcs_project_id",
+    "service_account_path": "your_gcs_service_account_path"
+  }
+}
+```
+
+ABS(Azure Blob Storage)
+
+```json
+{
+  "addr": "http://127.0.0.1:65001",
+  "header": {},
+  "object_storage": {
+    "type": "abs",
+    "account_name": "your_abs_account_name",
+    "account_key": "your_abs_account_key",
+    "container_name": "your_abs_container_name"
+  }
+}
+```
+
+## TorchServe integrates Dragonfly Endpoint plugin
+
+For detailed installation documentation, please refer to [TorchServe document](https://pytorch.org/serve/).
+
+### Binary installation
+
+#### The Prerequisites
+
+| Name       | Version | Document                                                                     |
+| ---------- | ------- | ---------------------------------------------------------------------------- |
+| Python     | 3.8.0+  | [https://www.python.org/](https://www.python.org/)                           |
+| TorchServe | 0.4.0+  | [pytorch.org/serve/](https://pytorch.org/serve/)                             |
+| Java       | 11      | [https://openjdk.org/projects/jdk/11/](https://openjdk.org/projects/jdk/11/) |
+
+Install TorchServe dependencies and torch-model-archiver：
+
+```bash
+python ./ts_scripts/install_dependencies.py
+conda install torchserve torch-model-archiver torch-workflow-archiver -c pytorch
+```
+
+Clone TorchServe repository：
+
+```bash
+git clone https://github.com/pytorch/serve.gitcd serve
+```
+
+Create [model-store](https://pytorch.org/serve/getting_started.html?highlight=model+store) directory to store the models：
+
+```bash
+mkdir model-storechmod 777 model-store
+```
+
+Create [plugins-path](https://github.com/pytorch/serve/tree/master/plugins/docs) directory to store the binaries of the plugin：
+
+```bash
+mkdir plugins-path
+```
+
+#### Package Dragonfly Endpoint plugin
+
+Clone dragonfly-endpoint repository：
+
+```bash
+git clone https://github.com/dragonflyoss/dragonfly-endpoint.git
+```
+
+Build the dragonfly-endpoint project to generate file in the build/libs directory:
+
+```bash
+cd ./dragonfly-endpointgradle shadowJar
+```
+
+Note: Due to the limitations of TorchServe’s JVM, the best Java version for Gradle is 11, as a higher version will cause the plugin to fail to parse.
+
+Move the Jar file into the plugins-path directory:
+
+```bash
+mv build/libs/dragonfly_endpoint-1.0-all.jar  <your plugins-path>
+```
+
+Prepare the plugin configuration config.json, and use S3 as the object storage:
+
+```json
+{
+  "addr": "http://127.0.0.1:65001",
+  "header": {},
+  "filter": [
+    "X-Amz-Algorithm",
+    "X-Amz-Credential",
+    "X-Amz-Date",
+    "X-Amz-Expires",
+    "X-Amz-SignedHeaders",
+    "X-Amz-Signature"
+  ],
+  "object_storage": {
+    "type": "s3",
+    "bucket_name": "your_s3_bucket_name",
+    "region": "your_s3_region",
+    "access_key": "your_s3_access_key",
+    "secret_key": "your_s3_secret_key"
+  }
+}
+```
+
+Set the environment variables for the configuration:
+
+```bash
+export DRAGONFLY_ENDPOINT_CONFIG=/etc/dragonfly-endpoint/config.json
+```
+
+–model-storesets the previously created directory to store the models and –plugins-path sets the previously created directory to store the plugins. Start the TorchServe with Dragonfly Endpoint plugin:
+
+```bash
+torchserve --start --model-store <path-to-model-store-file> --plugins-path=<path-to-plugin-jars>
+```
+
+#### Verify
+
+Prepare the model. Download a model from [Model ZOO](https://pytorch.org/serve/model_zoo.html#) or package the model refer to [Torch Model archiver for TorchServe](https://github.com/pytorch/serve/tree/master/model-archiver). Use squeezenet1\_1\_scripted.mar model to verify：
+
+```bash
+wget https://torchserve.pytorch.org/mar_files/squeezenet1_1_scripted.mar
+```
+
+Upload the model to object storage. For detailed uploading the model to S3, please refer to [S3](https://aws.amazon.com/s3/?nc1=h_ls)。
+
+```bash
+# Download the command line toolpip install awscli# Configure the key as promptedaws configure# Upload fileaws s3 cp < local file path > s3://< bucket name >/< Target path >
+```
+
+TorchServe plugin is named dragonfly, please refer to [TorchServe Register API](https://pytorch.org/serve/management_api.html#register-a-model) for details of plugin API. The url parameter are not supported and add the file\_name parameter which is the model file name to download.
+
+Download the model:
+
+```bash
+curl -X POST  "http://localhost:8081/dragonfly/models?file_name=squeezenet1_1.mar"
+```
+
+Verify the model download successful:
+
+```json
+{"Status": "Model \"squeezenet1_1\" Version: 1.0 registered with 0 initial workers. Use scale workers API to add workers for the model."}
+```
+
+Added model worker for inference:
+
+```bash
+curl -v -X PUT "http://localhost:8081/models/squeezenet1_1?min_worker=1"
+```
+
+Check the number of worker is increased:
+
+```bash
+* About to connect() to localhost port 8081 (#0)
+*   Trying ::1...
+* Connected to localhost (::1) port 8081 (#0)
+> PUT /models/squeezenet1_1?min_worker=1 HTTP/1.1
+> User-Agent: curl/7.29.0
+> Host: localhost:8081
+> Accept: */*
+>
+< HTTP/1.1 202 Accepted
+< content-type: application/json
+< x-request-id: 66761b5a-54a7-4626-9aa4-12041e0e4e63
+< Pragma: no-cache
+< Cache-Control: no-cache; no-store, must-revalidate, private
+< Expires: Thu, 01 Jan 1970 00:00:00 UTC
+< content-length: 47
+< connection: keep-alive
+<
+{  "status": "Processing worker updates..."}
+* Connection #0 to host localhost left intact
+```
+
+Call inference API:
+
+```bash
+# Prepare pictures that require reasoning
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/dogs-before.jpg
+
+# Call inference API
+curl http://localhost:8080/predictions/squeezenet1_1 -T kitten_small.jpg -T dogs-before.jpg
+```
+
+Check the response successful:
+
+```json
+{
+  "lynx": 0.5455784201622009,
+  "tabby": 0.2794168293476105,
+  "Egyptian_cat": 0.10391931980848312,
+  "tiger_cat": 0.062633216381073,
+  "leopard": 0.005019133910536766
+}
+```
+
+### Install TorchServe with Docker
+
+#### Docker configuration
+
+Pull dragonflyoss/dragonfly-endpoint image with the plugin. The following is an example of the CPU version of TorchServe, refer to [Dockerfile](https://github.com/dragonflyoss/dragonfly-endpoint/blob/main/images/Dockerfile).
+
+```bash
+docker pull dragonflyoss/dragonfly-endpoint
+```
+
+Create [model-store](https://pytorch.org/serve/getting_started.html?highlight=model+store) directory to store the model files：
+
+```bash
+mkdir model-storechmod 777 model-store
+```
+
+Prepare the plugin configuration config.json, and use S3 as the object storage:
+
+```json
+{
+  "addr": "http://127.0.0.1:65001",
+  "header": {},
+  "filter": [
+    "X-Amz-Algorithm",
+    "X-Amz-Credential",
+    "X-Amz-Date",
+    "X-Amz-Expires",
+    "X-Amz-SignedHeaders",
+    "X-Amz-Signature"
+  ],
+  "object_storage": {
+    "type": "s3",
+    "bucket_name": "your_s3_bucket_name",
+    "region": "your_s3_region",
+    "access_key": "your_s3_access_key",
+    "secret_key": "your_s3_secret_key"
+  }
+}
+```
+
+Set the environment variables for the configuration:
+
+```bash
+export DRAGONFLY_ENDPOINT_CONFIG=/etc/dragonfly-endpoint/config.json
+```
+
+Mount the model-store and dragonfly-endpoint configuration directory. Run the container:
+
+```bash
+sudo docker run --rm -it --network host \
+  -v $(pwd)/model-store:/home/model-server/model-store \
+  -v ${DRAGONFLY_ENDPOINT_CONFIG}:${DRAGONFLY_ENDPOINT_CONFIG} \
+  dragonflyoss/dragonfly-endpoint:latest
+```
+
+#### How to Verify
+
+Prepare the model. Download a model from [Model ZOO](https://pytorch.org/serve/model_zoo.html#) or package the model refer to [Torch Model archiver for TorchServe](https://github.com/pytorch/serve/tree/master/model-archiver). Use squeezenet1\_1\_scripted.mar model to verify：
+
+```bash
+wget https://torchserve.pytorch.org/mar_files/squeezenet1_1_scripted.mar
+```
+
+Upload the model to object storage. For detailed uploading the model to S3, please refer to [S3](https://aws.amazon.com/s3/?nc1=h_ls)。
+
+```bash
+# Download the command line tool
+pip install awscli
+
+# Configure the key as prompted
+aws configure
+
+# Upload file
+aws s3 cp <local file path> s3://<bucket name>/<Target path>
+```
+
+TorchServe plugin is named dragonfly, please refer to [TorchServe Register API](https://pytorch.org/serve/management_api.html#register-a-model) for details of plugin API. The url parameter are not supported and add the file\_name parameter which is the model file name to download.
+
+Download a model：
+
+```bash
+curl -X POST  "http://localhost:8081/dragonfly/models?file_name=squeezenet1_1.mar"
+```
+
+Verify the model download successful:
+
+```json
+{"Status": "Model \"squeezenet1_1\" Version: 1.0 registered with 0 initial workers. Use scale workers API to add workers for the model."}
+```
+
+Added model worker for inference:
+
+```bash
+curl -v -X PUT "http://localhost:8081/models/squeezenet1_1?min_worker=1"
+```
+
+Check the number of worker is increased:
+
+```text
+* About to connect() to localhost port 8081 (#0)
+*   Trying ::1...
+* Connected to localhost (::1) port 8081 (#0)
+> PUT /models/squeezenet1_1?min_worker=1 HTTP/1.1
+> User-Agent: curl/7.29.0
+> Host: localhost:8081
+> Accept: */*
+>
+< HTTP/1.1 202 Accepted
+< content-type: application/json
+< x-request-id: 66761b5a-54a7-4626-9aa4-12041e0e4e63
+< Pragma: no-cache
+< Cache-Control: no-cache; no-store, must-revalidate, private
+< Expires: Thu, 01 Jan 1970 00:00:00 UTC
+< content-length: 47
+< connection: keep-alive
+<
+{  "status": "Processing worker updates..."}
+* Connection #0 to host localhost left intact
+```
+
+Call inference API:
+
+```bash
+# Prepare pictures that require reasoning
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/dogs-before.jpg
+
+# Call inference API
+curl http://localhost:8080/predictions/squeezenet1_1 -T kitten_small.jpg -T dogs-before.jpg
+```
+
+Check the response successful:
+
+```json
+{
+  "lynx": 0.5455784201622009,
+  "tabby": 0.2794168293476105,
+  "Egyptian_cat": 0.10391931980848312,
+  "tiger_cat": 0.062633216381073,
+  "leopard": 0.005019133910536766
+}
+```
+
+## Performance testing
+
+Test the performance of single-machine model download by TorchServe API after the integration of Dragonfly P2P. Due to the influence of the network environment of the machine itself, the actual download time is not important, but the ratio of the increase in the download time in different scenarios is very important.
+
+![Bar chart showing TorchServe API, TouchServe API & Dragonfly Cold Boot, Hit Dragonfly Remote Peer Cache and Hit Dragonfly Local Peer Cache performance based on time to download](https://www.cncf.io/wp-content/uploads/2023/12/Dragonfly3.png)
+
+- TorchServe API: Use signed URL provided by Object Storage to download the model directly.
+- TorchServe API & Dragonfly Cold Boot: Use TorchServe API to download model via Dragonfly P2P network and no cache hits.
+- Hit Remote Peer: Use TorchServe API to download model via Dragonfly P2P network and hit the remote peer cache.
+- Hit Local Peer: Use TorchServe API to download model via Dragonfly P2P network and hit the local peer cache.
+
+Test results show TorchServe and Dragonfly integration. It can effectively reduce the file download time. Note that this test was a single-machine test, which means that in the case of cache hits, the performance limitation is on the disk. If Dragonfly is deployed on multiple machines for P2P download, the models download speed will be faster.
+
+## Links
+
+### Dragonfly community
+
+- Website: [https://d7y.io/](https://d7y.io/)
+- Github Repo: [https://github.com/dragonflyoss/Dragonfly2](https://github.com/dragonflyoss/Dragonfly2)
+- Slack Channel: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
+- Discussion Group: [dragonfly-discuss@googlegroups.com](mailto:dragonfly-discuss@googlegroups.com)
+- Twitter: [@dragonfly\_oss](https://twitter.com/dragonfly_oss)
+
+### Pytorch
+
+- Website: [https://pytorch.org/](https://pytorch.org/)
+- Github Repo: [https://github.com/pytorch/pytorch](https://github.com/pytorch/pytorch)
+- TorchServe Document: [https://pytorch.org/serve/](https://pytorch.org/serve/)
+
+TorchServe Github Repo: [https://github.com/pytorch/serve](https://github.com/pytorch/serve)


### PR DESCRIPTION
- Add release notes for Dragonfly v2.0.9 and v2.1.0 with feature updates
- Include Volcano Engine's image acceleration practices using Dragonfly
- Document Ant Group's security technology practices with Nydus and Dragonfly
- Add guides on using Dragonfly for multi-cluster Kubernetes image distribution
- Cover integrations with Hugging Face and TorchServe for model distribution