### PR TITLE
docs: move 2025-06-10 video to Chinese sessions

### DIFF
--- a/sidebars/videos.js
+++ b/sidebars/videos.js
@@ -30,6 +30,7 @@ module.exports = {
           label: 'Sessions in Chinese',
           collapsed: false,
           items: [
+            'sessions/zh/2025-06-10',
             'sessions/zh/2024-09-06',
             'sessions/zh/2024-09-05',
             'sessions/zh/2023-11-04',

--- a/videos/sessions/zh/2025-06-10.md
+++ b/videos/sessions/zh/2025-06-10.md
@@ -1,0 +1,20 @@
+---
+title: AI Model Distribution Challenges and Best Practices
+---
+
+Speakers: [Wenbo Qi](https://github.com/gaius-qi), [Xiaoya Xia](https://github.com/xiaoya-yaya), [Peng Tao](https://github.com/bergwolf), Wenpeng Li, [Han Jiang](https://github.com/CormickKneey)
+
+> This video is posted in 2025-06-10.
+
+As the demand for scalable AI/ML grows, efficiently distributing AI models in cloud-native infrastructure has become a pivotal challenge for enterprises.
+The panel dives into the technical and operational strategies for deploying models at scale -- from optimizing model storage and transfer to ensuring
+consistency across clusters and regions. Experts from different companies and CNCF projects will debate critical questions like: How can Kubernetes-native
+workflows automate and accelerate model distribution while minimizing latency and bandwidth costs? How to efficiently distribute huge models sizing
+hundreds of GBs or TBs? What are the challenges proposed by distributed inference and the prefilling-decoding architecture? How are models updated in
+the reinforcement learning post-training paradigm? What role do standards like OCI artifacts or specialized registries play in streamlining versioned model delivery?
+
+<!-- markdownlint-disable -->
+
+<iframe width="720" height="480" src="https://www.youtube.com/embed/dYVgmr7S-rE?si=mbjNyILHZI519WW4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen> </iframe>
+
+<!-- markdownlint-restore -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new session to the Chinese video sidebar and introduces the corresponding markdown file for the session. The session focuses on AI model distribution challenges and best practices, featuring expert insights and a linked video.

### Sidebar update:
* [`sidebars/videos.js`](diffhunk://#diff-60f48a80ba0497b3812eaddc7ec002ebb512b0dcfcc3de07939417baa4dafd55R33): Added a new session (`sessions/zh/2025-06-10`) to the "Sessions in Chinese" section.

### New session content:
* [`videos/sessions/zh/2025-06-10.md`](diffhunk://#diff-152eaaf9846ed15ed0a9bd8c15497a5e06aba345ee8a79377ae858c260828e07R1-R20): Created a markdown file for the session titled "AI Model Distribution Challenges and Best Practices," including details about the topic, speakers, and an embedded YouTube video.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
