### PR TITLE
docs: add concurrent_task_count and concurrent_peer_count for preheat

### DIFF
--- a/docs/advanced-guides/open-api/preheat.md
+++ b/docs/advanced-guides/open-api/preheat.md
@@ -32,12 +32,22 @@ Use Open API for preheating image. First create a POST request for preheating.
 
 - **url**: URL used to specify the resource to be preheated.
 
+- **concurrent_task_count**: Used to specify the maximum number of tasks (e.g., image layers) to preheat concurrently.
+  For example, if preheating 100 layers with ConcurrentTaskCount set to 10, up to 10 layers are processed simultaneously.
+  If ConcurrentPeerCount is 10 for 1000 peers, each layer is preheated by 10 peers concurrently.Default is 8, maximum is 100.
+
+- **concurrent_peer_count**: Used to specify the maximum number of peers to preheat concurrently for a single task (e.g., an image layer).
+  For example, if preheating a layer with ConcurrentPeerCount set to 10, up to 10 peers process that layer simultaneously.
+  Default is 500, maximum is 1000.
+
 - **platform**: The image type preheating task can specify the image architecture type. eg: linux/amd64、linux/arm64.
 
 - **scope**: Select the scope of preheat as needed.
+
   - **single_seed_peer**: Preheat to a seed peer.
 
   - **all_seed_peers**: Preheat to each seed peer in the P2P cluster.
+
     - **count**: The count of preheat seed peers desired.
       This field is used only when `IPs` is not specified. It has priority over `Percentage`.
       It must be a value between 1 and 200 (inclusive) if provided.
@@ -158,10 +168,20 @@ Use Open API for preheating file. First create a POST request for preheating.
 
 - **urls**: Used to specify the URL addresses of resources requiring preheating, supporting multiple URLs in a single preheat request.
 
+- **concurrent_task_count**: Used to specify the maximum number of tasks (e.g., image layers) to preheat concurrently.
+  For example, if preheating 100 layers with ConcurrentTaskCount set to 10, up to 10 layers are processed simultaneously.
+  If ConcurrentPeerCount is 10 for 1000 peers, each layer is preheated by 10 peers concurrently.Default is 8, maximum is 100.
+
+- **concurrent_peer_count**: Used to specify the maximum number of peers to preheat concurrently for a single task (e.g., an image layer).
+  For example, if preheating a layer with ConcurrentPeerCount set to 10, up to 10 peers process that layer simultaneously.
+  Default is 500, maximum is 1000.
+
 - **scope**: Select the scope of preheat as needed.
+
   - **single_seed_peer**: Preheat to a seed peer.
 
   - **all_seed_peers**: Preheat to each seed peer in the P2P cluster.
+
     - **count**: The count of preheat seed peers desired.
       This field is used only when `IPs` is not specified. It has priority over `Percentage`.
       It must be a value between 1 and 200 (inclusive) if provided.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Open API documentation for preheating resources by adding new configuration options for concurrency control. The changes enhance clarity and provide more detailed explanations of the parameters available for preheating tasks.

### Enhancements to concurrency control documentation:

* Added `concurrent_task_count` parameter to specify the maximum number of tasks (e.g., image layers) that can be preheated concurrently, with examples and default/maximum values. [[1]](diffhunk://#diff-be88592a5f6a1610f5d6cc076f599f191563f1fc32e5a22fecb117aea3406236R35-R50) [[2]](diffhunk://#diff-be88592a5f6a1610f5d6cc076f599f191563f1fc32e5a22fecb117aea3406236R171-R184)
* Added `concurrent_peer_count` parameter to specify the maximum number of peers that can preheat a single task concurrently, with examples and default/maximum values. [[1]](diffhunk://#diff-be88592a5f6a1610f5d6cc076f599f191563f1fc32e5a22fecb117aea3406236R35-R50) [[2]](diffhunk://#diff-be88592a5f6a1610f5d6cc076f599f191563f1fc32e5a22fecb117aea3406236R171-R184)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
