### PR TITLE
docs(dfdaemon): add schedulerClusterID to the host section

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -27,6 +27,11 @@ host:
 # # ip is the advertise ip of the host.
 # ip: ""
 
+# # scheduler_cluster_id is the ID of the cluster to which the scheduler belongs.
+# # NOTE: This field is used to identify the cluster to which the scheduler belongs.
+# # If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers.
+  schedulerClusterID: 1
+
 server:
   # pluginDir is the directory to store plugins.
   pluginDir: /var/lib/dragonfly/plugins/dfdaemon/
@@ -136,10 +141,6 @@ seedPeer:
   enable: true
   # type is the type of seed peer.
   type: super
-  # clusterID is the cluster id of the seed peer cluster.
-  clusterID: 1
-  # keepaliveInterval is the interval to keep alive with manager.
-  keepaliveInterval: 15s
 
 dynconfig:
   # refreshInterval is the interval to refresh dynamic configuration from manager.


### PR DESCRIPTION
This pull request updates the documentation for the `dfdaemon` client configuration to clarify cluster identification and remove redundant configuration fields. The main changes focus on how cluster IDs are specified for schedulers and seed peers.

Cluster identification improvements:

* Added a new `schedulerClusterID` field under the `host` section to explicitly specify the scheduler's cluster ID. This field takes precedence over other identification fields when listing schedulers.
* Removed the `clusterID` field from the `seedPeer` section, as cluster identification is now handled by the new `schedulerClusterID` field in the `host` section.

Configuration cleanup:

* Removed the `keepaliveInterval` field from the `seedPeer` section, streamlining the configuration options.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
