### PR TITLE
docs: add short option -I for --include-files and update examples in dfget.md

### DIFF
--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -118,8 +118,8 @@ Options:
       --filtered-query-param <FILTERED_QUERY_PARAMS>
           Filter the query parameters of the downloaded URL. If the download URL is the same, it will be scheduled as the same task. Examples: --filtered-query-param='signature' --filtered-query-param='timeout'
 
-      --include-files <INCLUDE_FILES>
-          Filter files to download in a directory using glob patterns relative to the root URL's path. Examples: --include-files='*.txt' --include-files='subdir/file.txt'
+  -I, --include-files <INCLUDE_FILES>
+          Filter files to download in a directory using glob patterns relative to the root URL's path. Examples: --include-files file.txt --include-files subdir/file.txt --include-files subdir/dir/
 
       --disable-back-to-source
           Disable back-to-source download when dfget download failed


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the documentation for the `dfget` client command options, specifically clarifying the usage and flag format for the `--include-files` option.

* Documentation update: Changed the flag for including files from `--include-files` to `-I, --include-files`, and improved example usage for glob patterns in the `docs/reference/commands/client/dfget.md` file.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
