### PR TITLE
docs: remove --log-dir and --log-max-files for command

### DIFF
--- a/docs/reference/commands/client/dfcache.md
+++ b/docs/reference/commands/client/dfcache.md
@@ -106,16 +106,6 @@ Options:
 
           [default: info]
 
-      --log-dir <LOG_DIR>
-          Specify the log directory
-
-          [default: /var/log/dragonfly/dfcache]
-
-      --log-max-files <LOG_MAX_FILES>
-          Specify the max number of log files
-
-          [default: 6]
-
       --console
           Specify whether to print log
 
@@ -173,16 +163,6 @@ Options:
 
           [default: info]
 
-      --log-dir <LOG_DIR>
-          Specify the log directory
-
-          [default: /var/log/dragonfly/dfcache]
-
-      --log-max-files <LOG_MAX_FILES>
-          Specify the max number of log files
-
-          [default: 6]
-
       --console
           Specify whether to print log
 
@@ -215,16 +195,6 @@ Options:
           Specify the logging level [trace, debug, info, warn, error]
 
           [default: info]
-
-      --log-dir <LOG_DIR>
-          Specify the log directory
-
-          [default: /var/log/dragonfly/dfcache]
-
-      --log-max-files <LOG_MAX_FILES>
-          Specify the max number of log files
-
-          [default: 6]
 
       --console
           Specify whether to print log

--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -165,16 +165,6 @@ Options:
 
           [default: info]
 
-      --log-dir <LOG_DIR>
-          Specify the log directory
-
-          [default: /var/log/dragonfly/dfget]
-
-      --log-max-files <LOG_MAX_FILES>
-          Specify the max number of log files
-
-          [default: 6]
-
       --console
           Specify whether to print log
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates documentation for the `dfcache` and `dfget` client commands by removing options related to log directory and log file limits. These changes help simplify the documentation and clarify the available command options.

Documentation cleanup:

* Removed the `--log-dir` and `--log-max-files` options, along with their descriptions and default values, from the `Options:` section of `docs/reference/commands/client/dfcache.md`. [[1]](diffhunk://#diff-049a00f4082fd66a93ca82c4472f9f8c0942ebcade015cf78640e0408e111043L109-L118) [[2]](diffhunk://#diff-049a00f4082fd66a93ca82c4472f9f8c0942ebcade015cf78640e0408e111043L176-L185) [[3]](diffhunk://#diff-049a00f4082fd66a93ca82c4472f9f8c0942ebcade015cf78640e0408e111043L219-L228)
* Removed the `--log-dir` and `--log-max-files` options, along with their descriptions and default values, from the `Options:` section of `docs/reference/commands/client/dfget.md`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
