### PR TITLE
docs: add protocol, tcpPort and quicPort for dfdaemon

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -39,6 +39,10 @@ server:
   cacheDir: /var/cache/dragonfly/dfdaemon/
 
 download:
+  # protocol that peers use to download piece (e.g., "tcp", "quic").
+  # When dfdaemon acts as a parent, it announces this protocol so downstream
+  # peers fetch pieces using it.
+  protocol: tcp
   server:
     # socketPath is the unix socket path for dfdaemon GRPC service.
     socketPath: /var/run/dragonfly/dfdaemon.sock
@@ -137,6 +141,11 @@ scheduler:
 # key: /etc/ssl/private/client.pem
 
 seedPeer:
+  server:
+    # port is the port to the tcp server.
+    tcpPort: 4005
+    # port is the port to the quic server.
+    quicPort: 4006
   # enable indicates whether enable seed peer.
   enable: true
   # type is the type of seed peer.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `dfdaemon.md` configuration documentation to clarify and expand options for download protocols and seed peer server ports. The changes help users better understand how to configure download protocols and specify ports for different server types.

Configuration documentation improvements:

* Added a `protocol` field to the `download` section to specify which protocol (e.g., "tcp", "quic") peers should use to download pieces, and clarified its use when dfdaemon acts as a parent.
* Added `tcpPort` and `quicPort` fields under the `seedPeer.server` section to allow explicit configuration of TCP and QUIC server ports.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
