### PR TITLE
docs: add description for download.protocol in dfdaemon

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -39,9 +39,12 @@ server:
   cacheDir: /var/cache/dragonfly/dfdaemon/
 
 download:
-  # protocol that peers use to download piece (e.g., "tcp", "quic").
+  # protocol that peers use to download piece, supported values: "tcp", "quic".
   # When dfdaemon acts as a parent, it announces this protocol so downstream
   # peers fetch pieces using it.
+  #
+  # QUIC: Recommended for high-bandwidth, long-RTT, or lossy networks.
+  # TCP: Recommended for high-bandwidth, low-RTT, or local-area network (LAN) environments.
   protocol: tcp
   server:
     # socketPath is the unix socket path for dfdaemon GRPC service.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation for the `download.protocol` configuration in `dfdaemon` to provide clearer guidance on when to use each supported protocol. The main improvement is the addition of recommendations for choosing between QUIC and TCP based on network conditions.

Configuration documentation improvements:

* Added explanations to the `download.protocol` option in `dfdaemon`'s configuration, clarifying that "quic" is recommended for high-bandwidth, long-RTT, or lossy networks, while "tcp" is recommended for high-bandwidth, low-RTT, or LAN environments.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
