### PR TITLE
docs: update client configuration for disk

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -54,11 +54,11 @@ download:
   # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 50GiB/s.
   rateLimit: 50GiB
   # pieceTimeout is the timeout for downloading a piece from source.
-  pieceTimeout: 60s
+  pieceTimeout: 360s
   # collectedPieceTimeout is the timeout for collecting one piece from the parent in the stream.
-  collectedPieceTimeout: 10s
+  collectedPieceTimeout: 360s
   # concurrentPieceCount is the number of concurrent pieces to download.
-  concurrentPieceCount: 10
+  concurrentPieceCount: 32
 
 upload:
   server:
@@ -188,10 +188,10 @@ gc:
     # distThreshold: 10TiB
     # distHighThresholdPercent is the high threshold percent of the disk usage.
     # If the disk usage is greater than the threshold, dfdaemon will do gc.
-    distHighThresholdPercent: 80
+    distHighThresholdPercent: 90
     # distLowThresholdPercent is the low threshold percent of the disk usage.
     # If the disk usage is less than the threshold, dfdaemon will stop gc.
-    distLowThresholdPercent: 60
+    distLowThresholdPercent: 70
 
 proxy:
   server:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the example configuration values in the `dfdaemon.md` documentation to optimize download performance and disk usage management. The most important changes are grouped below:

Download performance adjustments:
* Increased `pieceTimeout` and `collectedPieceTimeout` from 60s/10s to 360s to allow more time for downloading and collecting pieces.
* Increased `concurrentPieceCount` from 10 to 32 to enable more concurrent downloads.

Disk usage management:
* Raised `distHighThresholdPercent` from 80% to 90% and `distLowThresholdPercent` from 60% to 70% to adjust when garbage collection is triggered and stopped based on disk usage.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
