### PR TITLE
docs: add dataDir to reference of manager

### DIFF
--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -62,6 +62,10 @@ server:
   # In linux, default value is /usr/local/dragonfly/plugins.
   # In macos(just for testing), default value is /Users/$USER/.dragonfly/plugins.
   pluginDir: ''
+  # dataDir is the data directory.
+  # In linux, default value is /usr/local/dragonfly/data.
+  # In macos(just for testing), default value is /Users/$USER/.dragonfly/data.
+  dataDir: ''
 
 # Auth configuration.
 auth:


### PR DESCRIPTION
docs: add dataDir to reference of manager

## Description

docs: add dataDir to reference of manager

## Related Issue

[dragonfly #4476](https://github.com/dragonflyoss/dragonfly/pull/4476)

## Motivation and Context

keep document and source code consistent
