### PR TITLE
docs(dfdaemon): add option to derive task ID from OCI blob digest

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -254,6 +254,12 @@ proxy:
     # configuration to pull the image. The `X-Dragonfly-Registry` header can instead of the default address
     # of registry mirror.
     addr: https://index.docker.io
+    # enableTaskIDBasedBlobDigest indicates whether to use the blob digest for task ID calculation
+    # when downloading from OCI registries. When enabled for OCI blob URLs (e.g., /v2/<name>/blobs/sha256:<digest>),
+    # the task ID is derived from the blob digest rather than the full URL. This enables deduplication across
+    # registries - the same blob from different registries shares one task ID, eliminating redundant downloads
+    # and storage.
+    enableTaskIDBasedBlobDigest: false
   # # cert is the client cert path with PEM format for the registry.
   # # If registry use self-signed cert, the client should set the
   # # cert for the registry mirror.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new configuration option to the `proxy` section in the `dfdaemon.md` documentation. The change introduces an option to control how task IDs are calculated for OCI blob downloads, which can help deduplicate downloads and storage across registries.

Enhancement to deduplication and configuration:

* Added the `enableTaskIDBasedBlobDigest` option to the `proxy` section, allowing users to enable task ID calculation based on blob digest for OCI registries. This ensures that the same blob from different registries shares a single task ID, reducing redundant downloads and storage.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
