### PR TITLE
docs(dfdaemon): add backend.requestHeader configuration

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -284,6 +284,10 @@ metrics:
   # # ip is the listen ip of the metrics server.
   # ip: ""
 
+backend:
+  # requestHeader is the user customized request header which will be applied to the request when proxying to the origin server.
+  requestHeader: {}
+
 # tracing is the tracing configuration for dfdaemon.
 # tracing:
 #   # Protocol specifies the communication protocol for the tracing server.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request adds a new configuration section to the `dfdaemon` documentation, allowing users to set custom request headers when proxying to the origin server.

Configuration documentation update:

* Added a `backend.requestHeader` field to the `dfdaemon` configuration, enabling users to specify custom request headers for requests proxied to the origin server.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
