### PR TITLE
docs: add enableCacheTemporaryRedirect and cacheTemporaryRedirectTTL for dfdaemon

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -287,6 +287,16 @@ metrics:
 backend:
   # requestHeader is the user customized request header which will be applied to the request when proxying to the origin server.
   requestHeader: {}
+  # enableCacheTemporaryRedirect enables caching of 307 redirect URLs.
+  #
+  # Motivation: Dragonfly splits a download URL into multiple pieces and performs multiple
+  # requests. Without caching, each piece request may trigger the same 307 redirect again,
+  # repeating the redirect flow and adding extra latency. Caching the resolved redirect URL
+  # reduces repeated redirects and improves request performance.
+  enableCacheTemporaryRedirect: true
+  # cacheTemporaryRedirectTTL is the TTL for cached 307 redirect URLs. After
+  # this duration, the cached redirect target will expire and be re-resolved.
+  cacheTemporaryRedirectTTL: 600s
 
 # tracing is the tracing configuration for dfdaemon.
 # tracing:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `dfdaemon` client configuration documentation to introduce new options for handling HTTP 307 redirects. These changes improve download performance by allowing the client to cache temporary redirects, reducing redundant network requests.

Enhancements to HTTP 307 redirect handling:

* Added the `enableCacheTemporaryRedirect` option to allow caching of 307 redirect URLs, which helps avoid repeated redirects and reduces latency during downloads.
* Introduced the `cacheTemporaryRedirectTTL` option to specify the time-to-live for cached 307 redirect URLs, ensuring they are periodically refreshed.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
