### PR TITLE
docs: add video in KubeCon NA 2025

### DIFF
--- a/sidebars/videos.js
+++ b/sidebars/videos.js
@@ -10,6 +10,7 @@ module.exports = {
           label: 'Sessions in English',
           collapsed: false,
           items: [
+            'sessions/en/2025-11-13',
             'sessions/en/2024-03-23',
             'sessions/en/2023-05-02',
             'sessions/en/2023-02-15',

--- a/videos/sessions/en/2025-11-13.md
+++ b/videos/sessions/en/2025-11-13.md
@@ -1,0 +1,19 @@
+---
+title: Dragonfly v2.3.0 - Intro, Updates, Model Distribution With Cloud Native Infra
+---
+
+Speakers: [Wenbo Qi](https://github.com/gaius-qi), [Tao Peng](https://github.com/bergwolf)
+
+> This video is posted in 2024-03-23.
+
+Dragonfly provides efficient, stable, and secure file distribution and image acceleration using P2P technology
+within cloud-native architectures. This talk will briefly introduce Dragonfly and highlight the features
+of its latest version. Key updates include enhanced security and new functionalities tailored for more efficient
+and robust model distribution. We will also demonstrate how Dragonfly preheats and distributes
+AI models (packaged as OCI Artifacts) to read-only volumes in Kubernetes, enabling faster deployments.
+
+<!-- markdownlint-disable -->
+
+<iframe width="720" height="480" src="https://www.youtube.com/embed/EeEjybbNMdE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen> </iframe>
+
+<!-- markdownlint-restore -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new session video page for an upcoming talk on Dragonfly v2.3.0, including speaker details, a session summary, and an embedded YouTube video.

New session content:

* Added a new markdown file `2025-11-13.md` under `videos/sessions/en/` with the title, speaker information, a summary of the session's content, and an embedded YouTube video for the Dragonfly v2.3.0 talk.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
