### PR TITLE
docs(config): fix typo in dfdaemon configuration

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -179,24 +179,24 @@ gc:
   policy:
     # taskTTL is the ttl of the task.
     taskTTL: 720h
-    # # distThreshold optionally defines a specific disk capacity to be used as the base for
-    # # calculating GC trigger points with `distHighThresholdPercent` and `distLowThresholdPercent`.
+    # # diskThreshold optionally defines a specific disk capacity to be used as the base for
+    # # calculating GC trigger points with `diskHighThresholdPercent` and `diskLowThresholdPercent`.
     # #
-    # # - If a value is provided (e.g., "500GB"), the percentage-based thresholds (`distHighThresholdPercent`,
-    # #   `distLowThresholdPercent`) are applied relative to this specified capacity.
+    # # - If a value is provided (e.g., "500GB"), the percentage-based thresholds (`diskHighThresholdPercent`,
+    # #   `diskLowThresholdPercent`) are applied relative to this specified capacity.
     # # - If not provided or set to 0 (the default behavior), these percentage-based thresholds are applied
     # #   relative to the total actual disk space.
     # #
     # # This allows dfdaemon to effectively manage a logical portion of the disk for its cache,
     # # rather than always considering the entire disk volume.
     #
-    # distThreshold: 10TiB
-    # distHighThresholdPercent is the high threshold percent of the disk usage.
+    # diskThreshold: 10TiB
+    # diskHighThresholdPercent is the high threshold percent of the disk usage.
     # If the disk usage is greater than the threshold, dfdaemon will do gc.
-    distHighThresholdPercent: 90
-    # distLowThresholdPercent is the low threshold percent of the disk usage.
+    diskHighThresholdPercent: 90
+    # diskLowThresholdPercent is the low threshold percent of the disk usage.
     # If the disk usage is less than the threshold, dfdaemon will stop gc.
-    distLowThresholdPercent: 70
+    diskLowThresholdPercent: 70
 
 proxy:
   server:
@@ -300,7 +300,7 @@ health:
     port: 4003
   # # ip is the listen ip of the health server.
   # ip: ""
-  
+
 backend:
   # requestHeader is the user customized request header which will be applied to the request when proxying to the origin server.
   requestHeader: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request updates the configuration documentation for the garbage collection (GC) policy in `dfdaemon.md` to improve clarity and consistency in naming. The main change is renaming the disk-related threshold parameters from `dist*` to `disk*` to better reflect their purpose.

Improvements to documentation clarity and consistency:

* Renamed `distThreshold`, `distHighThresholdPercent`, and `distLowThresholdPercent` to `diskThreshold`, `diskHighThresholdPercent`, and `diskLowThresholdPercent` throughout the GC policy configuration section for clearer parameter naming.
* Updated all related comments and examples to use the new `disk*` parameter names, ensuring consistency and reducing confusion for users configuring disk usage thresholds.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
