### PR TITLE
docs: optimize nydus timeout and retry configuration

### DIFF
--- a/docs/operations/integrations/container-runtime/nydus.md
+++ b/docs/operations/integrations/container-runtime/nydus.md
@@ -536,7 +536,7 @@ download:
   # --  pieceTimeout is the timeout for downloading a piece from source.
   pieceTimeout: 40s
   # -- collected_piece_timeout is the timeout for collecting one piece from the parent in the stream.
-  collectedPieceTimeout: 5s
+  collectedPieceTimeout: 2s
 storage:
   # -- writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache).
   writePieceTimeout: 30s
@@ -548,11 +548,11 @@ Please refer to [scheduler config](../../../reference/configuration/scheduler.md
 ```yaml
 scheduler:
   # -- retryBackToSourceLimit reaches the limit, then the peer back-to-source.
-  retryBackToSourceLimit: 3
+  retryBackToSourceLimit: 1
   # -- Retry scheduling limit times.
-  retryLimit: 5
+  retryLimit: 3
   # -- Retry scheduling interval.
-  retryInterval: 100ms
+  retryInterval: 50ms
 ```
 
 ## Performance testing {#performance-testing}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Nydus integration documentation to reflect changes in timeout and retry-related configuration values. The main focus is on reducing timeouts and retry limits, which can lead to faster failure handling and improved responsiveness in container runtime operations.

Configuration value adjustments:

* Reduced `collectedPieceTimeout` from 5s to 2s in the `download` section to decrease the waiting time for collecting a piece from the parent stream.
* Lowered `retryBackToSourceLimit` from 3 to 1, `retryLimit` from 5 to 3, and `retryInterval` from 100ms to 50ms in the `scheduler` section, making scheduling retries more aggressive and reducing overall delay in failure scenarios.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
