### PR TITLE
feat: add d7y.io/snapshotter go import

### DIFF
--- a/blog/2026-01-15-cncf-announces-dragonfly-graduation/index.md
+++ b/blog/2026-01-15-cncf-announces-dragonfly-graduation/index.md
@@ -69,7 +69,7 @@ Additionally, a **third-party security audit** of Dragonfly was conducted. The D
 their TOC sponsors, completed both a self-assessment and a joint assessment with **CNCF TAG Security**, then collaborated with
 the Dragonfly security team on a threat model. After this, the team improved the project’s security policy.
 
-Learn more about Dragonfly and join the community: <https://d7y.io/>
+Learn more about Dragonfly and join the community: [https://d7y.io/](https://d7y.io/)
 
 ### Supporting Quotes
 

--- a/static/snapshotter/index.html
+++ b/static/snapshotter/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta name="go-import" content="d7y.io/snapshotter git https://github.com/dragonflyoss/snapshotter" />
+  </head>
+  <body>
+    Welcome to Dragonfly Snapshotter!
+  </body>
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a new HTML landing page for the Snapshotter service. The page includes metadata for Go package imports and a simple welcome message.

* New landing page: Added `static/snapshotter/index.html` with a basic HTML structure and a `<meta name="go-import">` tag to support Go module resolution for `d7y.io/snapshotter`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
