### PR TITLE
feat: add redirects for go-import

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,36 @@
 [build.environment]
 NODE_VERSION = "20"
 NPM_FLAGS = "--version"
+
+[[redirects]]
+  from = "/snapshotter"
+  to = "/snapshotter/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/snapshotter/"
+  to = "/snapshotter/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/dragonfly/v2"
+  to = "/dragonfly/v2/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/dragonfly/v2/"
+  to = "/dragonfly/v2/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/api/v2"
+  to = "/api/v2/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/v2/"
+  to = "/api/v2/index.html"
+  status = 200


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `netlify.toml` configuration to add several redirect rules for specific routes, ensuring that requests to certain paths are properly routed to their respective `index.html` files.

**Netlify redirect configuration:**

* Added redirects for `/snapshotter` and `/snapshotter/` to `/snapshotter/index.html` to ensure consistent routing for the snapshotter feature.
* Added redirects for `/dragonfly/v2` and `/dragonfly/v2/` to `/dragonfly/v2/index.html` to properly serve the Dragonfly v2 application entry point.
* Added redirects for `/api/v2` and `/api/v2/` to `/api/v2/index.html` to handle API v2 requests through the correct entry point.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
