### PR TITLE
chore: add required CNCF website footer text

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -169,10 +169,9 @@ const config = {
       ],
       copyright: `
         <br />
-        <strong>© Dragonfly Authors ${new Date().getFullYear()} | Documentation Distributed under <a href="https://creativecommons.org/licenses/by/4.0">CC-BY-4.0</a> </strong>
+        Copyright Dragonfly a Series of LF Projects, LLC.
         <br />
-        <br />
-        © ${new Date().getFullYear()} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/"> Trademark Usage</a> page.
+        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">lfprojects.org/policies</a>.
       `,
     },
   },


### PR DESCRIPTION
## Description

Now that the Dragonfly Contribution Agreement has been signed and it's been converted to a Series LLC entity, we need to update the website footer according to the CNCF [website guidelines](https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md).

<img width="1423" height="258" alt="image" src="https://github.com/user-attachments/assets/c274e2ae-cb5c-4ffc-a465-d5ee00b14e63" />

