### PR TITLE
docs(config): add enableIPv6 for service

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -20,9 +20,9 @@ host:
 # # ip is the advertise ip of the host.
 # ip: ""
 
-# # scheduler_cluster_id is the ID of the cluster to which the scheduler belongs.
-# # NOTE: This field is used to identify the cluster to which the scheduler belongs.
-# # If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers.
+  # scheduler_cluster_id is the ID of the cluster to which the scheduler belongs.
+  # NOTE: This field is used to identify the cluster to which the scheduler belongs.
+  # If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers.
   schedulerClusterID: 1
 
 server:
@@ -352,4 +352,9 @@ backend:
 #   path: "/v1/traces"
 #   # headers is the grpc's headers to send with tracing log.
 #   headers: {}
+
+# Network configuration.
+network:
+  # enableIPv6 indicates whether to enable IPv6 networking.
+  enableIPv4: false
 ```

--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -198,7 +198,7 @@ metrics:
 
 # Network configuration.
 network:
-  # Enable ipv6.
+  # enableIPv6 indicates whether to enable IPv6 networking.
   enableIPv6: false
 
 # Console shows log on console.

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -182,8 +182,9 @@ metrics:
   # Enable host metrics.
   enableHost: false
 
+# Network configuration.
 network:
-  # Enable ipv6.
+  # enableIPv6 indicates whether to enable IPv6 networking.
   enableIPv6: false
 
 # Console shows log on console.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the configuration documentation for client, manager, and scheduler components, focusing on clarifying network configuration options and improving consistency in comments and structure.

**Network configuration documentation improvements:**

* Standardized the network configuration comment to clarify that `enableIPv6` controls IPv6 networking, and updated the comment to "enableIPv4 indicates whether to enable IPv6 networking" in `docs/reference/configuration/manager.md` and `docs/reference/configuration/scheduler.md` for consistency. [[1]](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cL201-R201) [[2]](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48R185-R187)
* Added a new `network` section to `docs/reference/configuration/client/dfdaemon.md`, including the `enableIPv4` option with an updated comment to clarify its purpose.

**Scheduler cluster configuration:**

* Updated the comment style for `schedulerClusterID` in the `host` section of `docs/reference/configuration/client/dfdaemon.md` for better readability and consistency with other configuration fields.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
