### PR TITLE
docs: rename rateLimit to bandwidthLimit and update units

### DIFF
--- a/docs/advanced-guides/rate-limit.md
+++ b/docs/advanced-guides/rate-limit.md
@@ -17,28 +17,41 @@ and prefetch rate limit for the client.
 
 Used for P2P sharing of piece bandwidth.
 If the peak bandwidth is greater than the default outbound bandwidth,
-you can set `rateLimit` higher to increase the upload speed.
+you can set `bandwidthLimit` higher to increase the upload speed.
 It is recommended that the configuration be the same as the inbound bandwidth of the machine.
 Please refer to [dfdaemon config](../reference/configuration/client/dfdaemon.md).
 
 ```yaml
 upload:
-  # -- rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # -- bandwidthLimit is the default rate limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
 ```
 
 ### Inbound Bandwidth
 
 Used for back-to-source bandwidth and download bandwidth from remote peer.
 If the peak bandwidth is greater than the default inbound bandwidth,
-`rateLimit` can be set higher to increase download speed.
+`bandwidthLimit` can be set higher to increase download speed.
 It is recommended that the configuration be the same as the outbound bandwidth of the machine.
 Please refer to [dfdaemon config](../reference/configuration/client/dfdaemon.md).
 
 ```yaml
 download:
-  # -- rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # -- bandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
+```
+
+### Back To Source Bandwidth
+
+Used to limit bandwidth specifically for downloading content directly from the source.
+This allows controlling the back-to-source traffic separately from P2P download traffic,
+which helps reduce the load on source servers and prevents overwhelming them during peak usage.
+Please refer to [dfdaemon config](../reference/configuration/client/dfdaemon.md).
+
+```yaml
+download:
+  # backToSourceBandwidthLimit is the rate limit of the back to source speed in KB/MB/GB per second, default is 50GB/s.
+  backToSourceBandwidthLimit: 50GB
 ```
 
 ### Prefetch Bandwidth
@@ -50,9 +63,9 @@ refer to [dfdaemon config](../reference/configuration/client/dfdaemon.md).
 
 ```yaml
 proxy:
-  # prefetchRateLimit is the rate limit of the prefetch speed in KiB/MiB/GiB per second, default is 2GiB/s.
+  # prefetchBandwidthLimit is the rate limit of the prefetch speed in KB/MB/GB per second, default is 10GB/s.
   # The prefetch request has lower priority so limit the rate to avoid occupying the bandwidth impact other download tasks.
-  prefetchRateLimit: 2GiB
+  prefetchBandwidthLimit: 10GB
 ```
 
 ## Request

--- a/docs/operations/best-practices/deployment-best-practices.md
+++ b/docs/operations/best-practices/deployment-best-practices.md
@@ -87,28 +87,28 @@ The following documentation may help you to achieve better performance especiall
 
 Used for node P2P to share piece bandwidth.
 If the peak bandwidth is greater than the default outbound bandwidth,
-you can set `rateLimit` higher to increase the upload speed.
+you can set `bandwidthLimit` higher to increase the upload speed.
 It is recommended that the configuration be the same as the inbound bandwidth of the machine.
 Please refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.md).
 
 ```yaml
 upload:
-  # -- rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # -- bandwidthLimit is the default bandwidth limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
 ```
 
 #### Inbound Bandwidth
 
 Used for node back-to-source bandwidth and download bandwidth from remote peer.
 If the peak bandwidth is greater than the default inbound bandwidth,
-`rateLimit` can be set higher to increase download speed.
+`bandwidthLimit` can be set higher to increase download speed.
 It is recommended that the configuration be the same as the outbound bandwidth of the machine.
 Please refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.md).
 
 ```yaml
 download:
-  # -- rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # -- bandwidthLimit is the default bandwidth limit of the download speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
 ```
 
 ### Concurrency control

--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -44,8 +44,10 @@ download:
     socketPath: /var/run/dragonfly/dfdaemon.sock
     # request_rate_limit is the rate limit of the download request in the download grpc server, default is 5000 req/s.
     requestRateLimit: 5000
-  # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 50GiB/s.
-  rateLimit: 50GiB
+  # bandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
+  # backToSourceBandwidthLimit is the rate limit of the back to source speed in KB/MB/GB per second, default is 50GB/s.
+  backToSourceBandwidthLimit: 50GB
   # pieceTimeout is the timeout for downloading a piece from source.
   pieceTimeout: 360s
   # collectedPieceTimeout is the timeout for collecting one piece from the parent in the stream.
@@ -77,8 +79,8 @@ upload:
 #   key: /etc/ssl/private/client.pem
   # disableShared indicates whether disable to share data for other peers.
   disableShared: false
-  # rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 50GiB/s.
-  rateLimit: 50GiB
+  # bandwidthLimit is the default rate limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
 
 manager:
   # addr is manager address.
@@ -283,9 +285,9 @@ proxy:
   # If the value is "true", the range request will prefetch the entire file.
   # If the value is "false", the range request will fetch the range content.
   prefetch: false
-  # prefetchRateLimit is the rate limit of the prefetch speed in KiB/MiB/GiB per second, default is 5GiB/s.
+  # prefetchBandwidthLimit is the rate limit of the prefetch speed in KB/MB/GB per second, default is 10GB/s.
   # The prefetch request has lower priority so limit the rate to avoid occupying the bandwidth impact other download tasks.
-  prefetchRateLimit: 5GiB
+  prefetchBandwidthLimit: 10GB
   # readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
   readBufferSize: 4194304
 


### PR DESCRIPTION
This pull request updates the documentation to standardize bandwidth configuration terminology and improve clarity around bandwidth limiting options for uploads, downloads, and prefetching in the client (`dfdaemon`). The main changes include renaming configuration fields from `rateLimit` to `bandwidthLimit`, updating units to KB/MB/GB, introducing a new `backToSourceBandwidthLimit` option, and ensuring consistency across advanced guides, best practices, and reference documentation.

**Configuration terminology and field updates:**

* Renamed all occurrences of `rateLimit` to `bandwidthLimit` in documentation and configuration examples for both upload and download bandwidth, and updated units from KiB/MiB/GiB to KB/MB/GB for clarity and consistency. [[1]](diffhunk://#diff-66a63612f63249da948c800eff78edcf61e0c07b47214eb5d249b144b1a28ab6L20-R54) [[2]](diffhunk://#diff-98de546b81d7d6cbd415a981071dde7c9410168f379a58ca84e0bb582e1f3a48L90-R111) [[3]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL47-R50) [[4]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL80-R83)
* Updated the prefetch bandwidth configuration field from `prefetchRateLimit` to `prefetchBandwidthLimit` and increased the documented default from 2GiB/5GiB to 10GB. [[1]](diffhunk://#diff-66a63612f63249da948c800eff78edcf61e0c07b47214eb5d249b144b1a28ab6L53-R68) [[2]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL286-R290)

**New bandwidth limiting option:**

* Added documentation and configuration example for `backToSourceBandwidthLimit`, allowing users to limit bandwidth specifically for downloads directly from the origin source to help protect origin servers during peak usage. [[1]](diffhunk://#diff-66a63612f63249da948c800eff78edcf61e0c07b47214eb5d249b144b1a28ab6L20-R54) [[2]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL47-R50)

**Documentation consistency and clarity:**

* Ensured that all references, descriptions, and configuration snippets in the advanced guides, best practices, and reference documentation are consistent with the new field names and units. [[1]](diffhunk://#diff-66a63612f63249da948c800eff78edcf61e0c07b47214eb5d249b144b1a28ab6L20-R54) [[2]](diffhunk://#diff-98de546b81d7d6cbd415a981071dde7c9410168f379a58ca84e0bb582e1f3a48L90-R111) [[3]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL47-R50) [[4]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL80-R83) [[5]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL286-R290)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
