### PR TITLE
docs(configuration): add requestRateLimit for manager and scheduler

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -19,8 +19,8 @@ host:
 # hostname: ""
 # # ip is the advertise ip of the host.
 # ip: ""
-
-  # scheduler_cluster_id is the ID of the cluster to which the scheduler belongs.
+#
+  # schedulerClusterID is the ID of the cluster to which the scheduler belongs.
   # NOTE: This field is used to identify the cluster to which the scheduler belongs.
   # If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers.
   schedulerClusterID: 1
@@ -42,8 +42,18 @@ download:
   server:
     # socketPath is the unix socket path for dfdaemon GRPC service.
     socketPath: /var/run/dragonfly/dfdaemon.sock
-    # request_rate_limit is the rate limit of the download request in the download grpc server, default is 5000 req/s.
+    # The rate limit for the requests on the download gRPC server.
+    #
+    # This limit applies to the total number of gRPC requests per second, including:
+    # - Multiple requests within a single connection.
+    # - Single requests across different connections.
     requestRateLimit: 5000
+    # The buffer size for the request channel on the download gRPC server.
+    #
+    # This controls the capacity of the bounded channel used to queue
+    # incoming gRPC requests before they are processed. If the buffer is full,
+    # new requests will return a `RESOURCE_EXHAUSTED` error.
+    requestBufferSize: 1000
   # bandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 50GB/s.
   bandwidthLimit: 50GB
   # backToSourceBandwidthLimit is the rate limit of the back to source speed in KB/MB/GB per second, default is 50GB/s.
@@ -67,8 +77,19 @@ upload:
   # cert: /etc/ssl/certs/server.crt
   # # GRPC server key file path for mTLS.
   # key: /etc/ssl/private/server.pem
-    # request_rate_limit is the rate limit of the upload request in the upload grpc server, default is 5000 req/s.
+  #
+    # The rate limit for the requests on the upload gRPC server.
+    #
+    # This limit applies to the total number of gRPC requests per second, including:
+    # - Multiple requests within a single connection.
+    # - Single requests across different connections.
     requestRateLimit: 5000
+    # The buffer size for the request channel on the upload gRPC server.
+    #
+    # This controls the capacity of the bounded channel used to queue
+    # incoming gRPC requests before they are processed. If the buffer is full,
+    # new requests will return a `RESOURCE_EXHAUSTED` error.
+    requestBufferSize: 1000
 # # Client configuration for remote peer's upload server.
 # client:
 #   # CA certificate file path for mTLS.
@@ -97,7 +118,7 @@ scheduler:
   # Announcer will provide the scheduler with peer information for scheduling,
   # peer information includes cpu, memory, etc.
   announceInterval: 1m
-  # schedule_timeout is timeout for the scheduler to respond to a scheduling request from dfdaemon, default is 3 hours.
+  # scheduleTimeout is timeout for the scheduler to respond to a scheduling request from dfdaemon, default is 3 hours.
   #
   # If the scheduler's response time for a scheduling decision exceeds this timeout,
   # dfdaemon will encounter a `TokioStreamElapsed(Elapsed(()))` error.
@@ -200,8 +221,8 @@ gc:
     # #
     # # This allows dfdaemon to effectively manage a logical portion of the disk for its cache,
     # # rather than always considering the entire disk volume.
-    #
     # diskThreshold: 10TiB
+    #
     # diskHighThresholdPercent is the high threshold percent of the disk usage.
     # If the disk usage is greater than the threshold, dfdaemon will do gc.
     diskHighThresholdPercent: 90

--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -24,6 +24,10 @@ server:
     port:
       start: 65003
       end: 65003
+    # RequestRateLimit is the maximum number of requests per second for the gRPC server. It limits both the rate of
+    # unary gRPC requests and the rate of new stream gRPC connection, default is 4000 req/s.
+    requestRateLimit: 4000
+
   # # GRPC server tls configuration.
   # tls:
   #   # CA certificate file path for mTLS.
@@ -167,9 +171,16 @@ job:
     # fillInterval is the interval for refilling the bucket.
     fillInterval: 1m
     # capacity is the maximum number of requests that can be consumed in a single fillInterval.
-    capacity: 5
+    capacity: 10
     # quantum is the number of tokens taken from the bucket for each request.
-    quantum: 5
+    quantum: 10
+  # gc configuration.
+  gc:
+    # interval is the interval of gc.
+    interval: 3h
+    # ttl is the ttl of job.
+    ttl: 6h
+
   # Sync peers configuration.
   syncPeers:
     # Interval is the interval for syncing all peers information from the scheduler and

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -15,14 +15,12 @@ server:
 # # Access ip for other services,
 # # when local ip is different with access ip, advertiseIP should be set.
 # advertiseIP: 127.0.0.1
-
 # # Access port for other services,
 # # when local ip is different with access port, advertisePort should be set.
 # advertisePort: 8002
-
 # # Listen ip.
 # listenIP: 0.0.0.0
-
+#
 # Port is the ip and port scheduler server listens on.
   port: 8002
 # # GRPC server tls configuration.
@@ -33,9 +31,10 @@ server:
 #   cert: /etc/ssl/certs/server.crt
 #   # Key file path for mTLS.
 #   key: /etc/ssl/private/server.pem
-
-# # Server host.
-# host: localhost
+#
+  # RequestRateLimit is the maximum number of requests per second for the gRPC server. It limits both the rate of
+  # unary gRPC requests and the rate of new stream gRPC connection, default is 4000 req/s.
+  requestRateLimit: 4000
 
   # logLevel specifies the logging level for the scheduler.
   # Default: "info"
@@ -71,13 +70,11 @@ server:
 
 # Scheduler policy configuration.
 scheduler:
-  # Algorithm configuration to use different scheduling algorithms,
-  # default configuration supports "default" and "ml"
-  # "default" is the rule-based scheduling algorithm,
-  # "ml" is the machine learning scheduling algorithm
-  # It also supports user plugin extension, the algorithm value is "plugin",
-  # and the compiled `d7y-scheduler-plugin-evaluator.so` file is added to
-  # the dragonfly working directory plugins.
+  # Algorithm configuration for different scheduling algorithms.
+  # Currently only supports "default".
+  # Also supports custom plugin extensions by setting the algorithm value to "plugin"
+  # and placing the compiled `d7y-scheduler-plugin-evaluator.so` file in the
+  # dragonfly working directory under the plugins folder.
   algorithm: default
   # backToSourceCount is single task allows the peer to back-to-source count.
   backToSourceCount: 200
@@ -86,7 +83,7 @@ scheduler:
   # Retry scheduling limit times.
   retryLimit: 5
   # Retry scheduling interval.
-  retryInterval: 400ms
+  retryInterval: 2s
   # GC metadata configuration.
   gc:
     # pieceDownloadTimeout is the timeout of downloading piece.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the configuration documentation for the client (`dfdaemon`), manager, and scheduler components, focusing on improving clarity, consistency, and adding new configuration options. The most significant changes are the addition of request rate limiting and buffer size options for gRPC servers, adjustments to job and scheduler parameters, and improvements to documentation wording and structure.

**gRPC Server Rate Limiting and Buffering:**

* Added `requestRateLimit` and `requestBufferSize` options to both the download and upload gRPC server sections in `dfdaemon` configuration, clarifying their effects and error handling. [[1]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL45-R56) [[2]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL70-R92)
* Introduced `requestRateLimit` option to the gRPC server configuration in both the manager and scheduler documentation, specifying per-second request limits. [[1]](diffhunk://#diff-67be962abbe1b7ac7e2f6d745b4e852e1373a1ceb7f92a8d053f1dbbdeba3c8cR27-R30) [[2]](diffhunk://#diff-bd00e339cebeaf484e9fc4718752f635da5d19831241e18bb6562847b1b56b48L36-R37)

**Job and GC Configuration Updates:**

* Increased the default `capacity` and `quantum` values for job rate limiting and added a new `gc` section with `interval` and `ttl` options in the manager configuration.
* Clarified and restructured the disk GC threshold documentation in the `dfdaemon` config.

**Scheduler and Algorithm Configuration:**

* Updated scheduler algorithm documentation to state that only "default" is currently supported, with instructions for custom plugin usage.
* Increased the scheduler's `retryInterval` from 400ms to 2s for scheduling retries.

**Naming and Documentation Consistency:**

* Standardized field names such as `schedulerClusterID` and `scheduleTimeout` for consistency and clarity in the `dfdaemon` config. [[1]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL22-R23) [[2]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL100-R121)
* Improved comments, formatting, and structure throughout the configuration files for better readability and maintainability.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
