### PR TITLE
docs: add hf:// protocol documentation for Hugging Face integration

### DIFF
--- a/docs/operations/integrations/hugging-face.md
+++ b/docs/operations/integrations/hugging-face.md
@@ -396,6 +396,67 @@ The expected output is as follows:
 
 <!-- markdownlint-restore -->
 
+## Use dfget to download files with hf:// protocol {#use-dfget-to-download-files-with-hf-protocol}
+
+Dragonfly's `dfget` command natively supports the `hf://` protocol, enabling direct P2P downloads from
+Hugging Face Hub without any proxy configuration. This is the simplest way to download models and datasets
+with Dragonfly acceleration.
+
+### URL Format {#url-format}
+
+The `hf://` URL format is:
+
+```text
+hf://[<repo_type>/]<owner>/<repo>[/<path>][@<revision>]
+```
+
+- **repo_type** (optional): `datasets`, `spaces`, or `models` (default).
+- **owner/repo**: The repository ID (e.g., `meta-llama/Llama-2-7b`).
+- **path** (optional): A specific file within the repository.
+- **revision** (optional): A branch, tag, or commit hash (defaults to `main`).
+
+### Download a single file {#download-a-single-file-with-dfget}
+
+```shell
+dfget hf://meta-llama/Llama-2-7b/config.json -O /tmp/config.json
+```
+
+### Download a single file with authentication {#download-a-single-file-with-authentication}
+
+For private repositories or to increase rate limits, use the `--hf-token` flag:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b/config.json -O /tmp/config.json --hf-token=<your_hf_token>
+```
+
+### Download an entire repository {#download-an-entire-repository-with-dfget}
+
+Use the `--recursive` flag to download all files in a repository:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b -O /tmp/llama-2-7b/ --recursive
+```
+
+### Download a dataset {#download-a-dataset-with-dfget}
+
+Prefix the URL with `datasets/` to download from a dataset repository:
+
+```shell
+# Download a specific file from a dataset.
+dfget hf://datasets/rajpurkar/squad/train-v2.0.json -O /tmp/train.json
+
+# Download an entire dataset.
+dfget hf://datasets/rajpurkar/squad -O /tmp/squad/ --recursive
+```
+
+### Download from a specific revision {#download-from-a-specific-revision-with-dfget}
+
+Append `@<revision>` to the URL to download from a specific branch, tag, or commit:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b/config.json@v1.0 -O /tmp/config.json
+```
+
 ## Performance testing {#performance-testing}
 
 Test the performance of single-machine file download by `hf_hub_download` API after the integration of

--- a/docs/operations/integrations/hugging-face.md
+++ b/docs/operations/integrations/hugging-face.md
@@ -202,6 +202,67 @@ Create a peer service using the configuration file:
 kubectl apply -f peer-service-config.yaml
 ```
 
+## Use dfget to download files with hf:// protocol {#use-dfget-to-download-files-with-hf-protocol}
+
+Dragonfly's `dfget` command natively supports the `hf://` protocol, enabling direct P2P downloads from
+Hugging Face Hub without any proxy configuration. This is the simplest way to download models and datasets
+with Dragonfly acceleration.
+
+### URL Format {#url-format}
+
+The `hf://` URL format is:
+
+```text
+hf://[<repo_type>/]<owner>/<repo>[/<path>][@<revision>]
+```
+
+- **repo_type** (optional): `datasets`, `spaces`, or `models` (default).
+- **owner/repo**: The repository ID (e.g., `meta-llama/Llama-2-7b`).
+- **path** (optional): A specific file within the repository.
+- **revision** (optional): A branch, tag, or commit hash (defaults to `main`).
+
+### Download a single file {#download-a-single-file-with-dfget}
+
+```shell
+dfget hf://meta-llama/Llama-2-7b/config.json -O /tmp/config.json
+```
+
+### Download a single file with authentication {#download-a-single-file-with-authentication}
+
+For private repositories or to increase rate limits, use the `--hf-token` flag:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b/config.json -O /tmp/config.json --hf-token=<your_hf_token>
+```
+
+### Download an entire repository {#download-an-entire-repository-with-dfget}
+
+Use the `--recursive` flag to download all files in a repository:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b -O /tmp/llama-2-7b/ --recursive
+```
+
+### Download a dataset {#download-a-dataset-with-dfget}
+
+Prefix the URL with `datasets/` to download from a dataset repository:
+
+```shell
+# Download a specific file from a dataset.
+dfget hf://datasets/rajpurkar/squad/train-v2.0.json -O /tmp/train.json
+
+# Download an entire dataset.
+dfget hf://datasets/rajpurkar/squad -O /tmp/squad/ --recursive
+```
+
+### Download from a specific revision {#download-from-a-specific-revision-with-dfget}
+
+Append `@<revision>` to the URL to download from a specific branch, tag, or commit:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b/config.json@v1.0 -O /tmp/config.json
+```
+
 ## Use Hub Python Library to download files and distribute traffic through Draognfly {#use-hub-python-library-to-download-files-and-distribute-traffic-through-draognfly}
 
 Any API in the [Hub Python Library](https://huggingface.co/docs/huggingface_hub/index)
@@ -395,67 +456,6 @@ The expected output is as follows:
 ```
 
 <!-- markdownlint-restore -->
-
-## Use dfget to download files with hf:// protocol {#use-dfget-to-download-files-with-hf-protocol}
-
-Dragonfly's `dfget` command natively supports the `hf://` protocol, enabling direct P2P downloads from
-Hugging Face Hub without any proxy configuration. This is the simplest way to download models and datasets
-with Dragonfly acceleration.
-
-### URL Format {#url-format}
-
-The `hf://` URL format is:
-
-```text
-hf://[<repo_type>/]<owner>/<repo>[/<path>][@<revision>]
-```
-
-- **repo_type** (optional): `datasets`, `spaces`, or `models` (default).
-- **owner/repo**: The repository ID (e.g., `meta-llama/Llama-2-7b`).
-- **path** (optional): A specific file within the repository.
-- **revision** (optional): A branch, tag, or commit hash (defaults to `main`).
-
-### Download a single file {#download-a-single-file-with-dfget}
-
-```shell
-dfget hf://meta-llama/Llama-2-7b/config.json -O /tmp/config.json
-```
-
-### Download a single file with authentication {#download-a-single-file-with-authentication}
-
-For private repositories or to increase rate limits, use the `--hf-token` flag:
-
-```shell
-dfget hf://meta-llama/Llama-2-7b/config.json -O /tmp/config.json --hf-token=<your_hf_token>
-```
-
-### Download an entire repository {#download-an-entire-repository-with-dfget}
-
-Use the `--recursive` flag to download all files in a repository:
-
-```shell
-dfget hf://meta-llama/Llama-2-7b -O /tmp/llama-2-7b/ --recursive
-```
-
-### Download a dataset {#download-a-dataset-with-dfget}
-
-Prefix the URL with `datasets/` to download from a dataset repository:
-
-```shell
-# Download a specific file from a dataset.
-dfget hf://datasets/rajpurkar/squad/train-v2.0.json -O /tmp/train.json
-
-# Download an entire dataset.
-dfget hf://datasets/rajpurkar/squad -O /tmp/squad/ --recursive
-```
-
-### Download from a specific revision {#download-from-a-specific-revision-with-dfget}
-
-Append `@<revision>` to the URL to download from a specific branch, tag, or commit:
-
-```shell
-dfget hf://meta-llama/Llama-2-7b/config.json@v1.0 -O /tmp/config.json
-```
 
 ## Performance testing {#performance-testing}
 

--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -157,6 +157,25 @@ dfget cos://<bucket>/<path> -O /tmp/path/ --recursive --storage-access-key-id=<a
 dfget hdfs://<path>/file.txt -O /tmp/file.txt  --hdfs-delegation-token <hadoop_delegation_token>
 ```
 
+#### Download with Hugging Face protocol
+
+```shell
+# Download a single file from a model repository.
+dfget hf://<owner>/<repo>/<path> -O /tmp/model.safetensors
+
+# Download a single file with authentication for private repositories.
+dfget hf://<owner>/<repo>/<path> -O /tmp/model.safetensors --hf-token=<token>
+
+# Download an entire repository.
+dfget hf://<owner>/<repo> -O /tmp/repo/ --recursive
+
+# Download a file from a dataset repository.
+dfget hf://datasets/<owner>/<repo>/<path> -O /tmp/train.json
+
+# Download from a specific revision (branch, tag, or commit).
+dfget hf://<owner>/<repo>/<path>@<revision> -O /tmp/model.safetensors
+```
+
 <!-- markdownlint-restore -->
 
 ## Log {#log}


### PR DESCRIPTION
## What is the purpose of the change

Add documentation for the native `hf://` protocol support in `dfget`, which enables direct P2P downloads from Hugging Face Hub repositories.

Related to: https://github.com/dragonflyoss/client/pull/1665

### Changes

**`docs/operations/integrations/hugging-face.md`**:
- Added new section "Use dfget to download files with hf:// protocol" documenting:
  - URL format specification
  - Single file download
  - Authentication with `--hf-token`
  - Recursive repository download
  - Dataset download
  - Revision-specific download

**`docs/reference/commands/client/dfget.md`**:
- Added "Download with Hugging Face protocol" section with examples for models, datasets, authentication, recursive downloads, and revisions