### PR TITLE
docs: remove seedPeer.enable in scheduler config

### DIFF
--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -153,10 +153,14 @@ manager:
 
 # Seed peer configuration.
 seedPeer:
-  # Scheduler enable seed peer as P2P peer,
-  # if the value is false, P2P network will not be back-to-source through
-  # seed peer but by peer and preheat feature does not work.
-  enable: true
+  # # GRPC client tls configuration.
+  # tls:
+  #   # CA certificate file path for mTLS.
+  #   caCert: /etc/ssl/certs/ca.crt
+  #   # Certificate file path for mTLS.
+  #   cert: /etc/ssl/certs/client.crt
+  #   # Key file path for mTLS.
+  #   key: /etc/ssl/private/client.pem
 
 # Machinery async job configuration,
 # see https://github.com/RichardKnop/machinery.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation for the scheduler configuration by removing the explanation of the `enable` field for seed peers and adding commented-out example configuration for GRPC client TLS settings. The most important changes are grouped below:

Improvements to seed peer configuration documentation:

* Removed the explanation and example for the `enable` field under `seedPeer`, which previously described how to enable seed peers as P2P peers and its effect on back-to-source and preheat features.

Addition of GRPC client TLS configuration examples:

* Added commented-out example configuration for GRPC client TLS under `seedPeer`, including fields for `caCert`, `cert`, and `key` to specify certificate and key file paths for mTLS.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4587
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
