### PR TITLE
feat: add note for downloading hf resource via UDS

### DIFF
--- a/docs/operations/integrations/hugging-face.md
+++ b/docs/operations/integrations/hugging-face.md
@@ -202,7 +202,10 @@ Create a peer service using the configuration file:
 kubectl apply -f peer-service-config.yaml
 ```
 
-## Use dfget to download files with hf:// protocol {#use-dfget-to-download-files-with-hf-protocol}
+## Use dfget to download files with `hf://` protocol {#use-dfget-to-download-files-with-hf-protocol}
+
+> Note: To use dfget inside an inference container, you must install dfget and transfer file content from dfdaemon's Unix
+> domain socket. For details, refer to [Download in Container](../../reference/commands/client/dfget.md#download-in-container).
 
 Dragonfly's `dfget` command natively supports the `hf://` protocol, enabling direct P2P downloads from
 Hugging Face Hub without any proxy configuration. This is the simplest way to download models and datasets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation for using the `hf://` protocol with `dfget` in inference containers. The most important change is the addition of a note clarifying installation requirements and linking to relevant instructions for container downloads.

Documentation improvements:

* Added a note explaining that to use `dfget` inside an inference container, installation is required and file content must be transferred from dfdaemon's Unix domain socket, with a link to detailed instructions.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
