### PR TITLE
docs: add specific revision docs for dfget

### DIFF
--- a/docs/operations/integrations/hugging-face.md
+++ b/docs/operations/integrations/hugging-face.md
@@ -246,6 +246,14 @@ Use the `--recursive` flag to download all files in a repository:
 dfget hf://meta-llama/Llama-2-7b -O /tmp/llama-2-7b/ --recursive
 ```
 
+### Download from a specific revision {#download-from-a-specific-revision-with-dfget}
+
+Set `--hf-revision` to download from a specific branch, tag, or commit:
+
+```shell
+dfget hf://meta-llama/Llama-2-7b --hf-revision v1.0 -O /tmp/llama-2-7b/ --recursive
+```
+
 ### Download a dataset {#download-a-dataset-with-dfget}
 
 Prefix the URL with `datasets/` to download from a dataset repository:
@@ -256,14 +264,6 @@ dfget hf://datasets/rajpurkar/squad/train-v2.0.json -O /tmp/train.json
 
 # Download an entire dataset.
 dfget hf://datasets/rajpurkar/squad -O /tmp/squad/ --recursive
-```
-
-### Download from a specific revision {#download-from-a-specific-revision-with-dfget}
-
-Append `@<revision>` to the URL to download from a specific branch, tag, or commit:
-
-```shell
-dfget hf://meta-llama/Llama-2-7b/config.json@v1.0 -O /tmp/config.json
 ```
 
 ## Use Hub Python Library to download files and distribute traffic through Draognfly {#use-hub-python-library-to-download-files-and-distribute-traffic-through-draognfly}

--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -169,11 +169,11 @@ dfget hf://<owner>/<repo>/<path> -O /tmp/model.safetensors --hf-token=<token>
 # Download an entire repository.
 dfget hf://<owner>/<repo> -O /tmp/repo/ --recursive
 
+# Download an entire repository from Hugging Face Hub with specified revision. If the revision is not specified, the default value is `main`.
+$ dfget hf://<owner>/<repo> --hf-revision main -O /tmp/repo/ -r
+
 # Download a file from a dataset repository.
 dfget hf://datasets/<owner>/<repo>/<path> -O /tmp/train.json
-
-# Download from a specific revision (branch, tag, or commit).
-dfget hf://<owner>/<repo>/<path>@<revision> -O /tmp/model.safetensors
 ```
 
 <!-- markdownlint-restore -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates documentation for downloading files from Hugging Face repositories using `dfget`, focusing on clarifying and standardizing how to specify a revision (branch, tag, or commit). The changes unify the usage of the `--hf-revision` flag for both repository and dataset downloads, replacing the previous `@<revision>` syntax and improving consistency across docs.

**Documentation improvements for revision selection:**

* Added a new section explaining how to use the `--hf-revision` flag to download from a specific revision, with clear examples for repository downloads in `hugging-face.md`.
* Removed the old documentation that used the `@<revision>` syntax for specifying revisions and replaced it with the standardized `--hf-revision` flag.
* Updated command reference documentation to show the preferred `--hf-revision` flag usage, clarifying that the default revision is `main` if not specified.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
