### PR TITLE
chore: add dragonfly-maintainers as codeowners alongside approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,2 @@
-# A CODEOWNERS file uses a pattern that follows the same rules used in gitignore files.
-# The pattern is followed by one or more GitHub usernames or team names using the
-# standard @username or @org/team-name format. You can also refer to a user by an
-# email address that has been added to their GitHub account, for example user@example.com
-
-*                                          @dragonflyoss/dragonfly-approvers
+*                                          @dragonflyoss/dragonfly-maintainers @dragonflyoss/dragonfly-approvers
 .github                                    @dragonflyoss/dragonfly-maintainers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
