### PR TITLE
docs: add 2026-04-03.md video

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
           position: 'left',
         },
         {
-          to: 'videos/sessions/en/2025-11-13',
+          to: 'videos/sessions/en/2026-04-03',
           activeBasePath: 'videos',
           label: 'Video',
           position: 'left',

--- a/sidebars/videos.js
+++ b/sidebars/videos.js
@@ -10,6 +10,7 @@ module.exports = {
           label: 'Sessions in English',
           collapsed: false,
           items: [
+            'sessions/en/2026-04-03',
             'sessions/en/2025-11-13',
             'sessions/en/2024-03-23',
             'sessions/en/2023-05-02',

--- a/videos/sessions/en/2026-04-03.md
+++ b/videos/sessions/en/2026-04-03.md
@@ -1,0 +1,23 @@
+---
+title: DevOps for Scientific Software - Tools, Practices, and Automation Strategies
+---
+
+Speakers: [Pavan Madduri](https://github.com/pmady)
+
+> This video is posted in 2026-04-03.
+
+Scientific software development often struggles with reproducibility, complex dependencies, and
+scaling across HPC and cloud environments. This session shows how modern DevOps practices can
+overcome these challenges and accelerate research. We’ll explore how GitHub Actions automates testing and
+deployment, while Docker ensures consistent, reproducible environments across teams. For large-scale
+workloads, Kubernetes provides robust orchestration, and Karpenter delivers intelligent autoscaling to optimize
+cost and performance dynamically. We’ll also cover observability and monitoring with Prometheus and Grafana, giving
+teams real-time insights into resource utilization and system health. By combining CI/CD, containerization,
+orchestration, and monitoring, attendees will learn practical strategies to make scientific software faster, more
+reliable, and ready to scale efficiently in HPC and cloud environments.
+
+<!-- markdownlint-disable -->
+
+<iframe width="720" height="480" src="https://www.youtube.com/embed/CnlTjDeHgl0?si=zHBcHeGWEzMzJ_Nc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+<!-- markdownlint-restore -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new video session entry for "DevOps for Scientific Software - Tools, Practices, and Automation Strategies" (dated 2026-04-03) to the documentation site. The changes ensure the new session appears in both the navigation and sidebar, and include the video content itself.

New video session addition:

* Added a new markdown file `videos/sessions/en/2026-04-03.md` with details and embedded YouTube video for the "DevOps for Scientific Software" session.

Site navigation and sidebar updates:

* Updated the `docusaurus.config.js` navigation to point the "Video" link to the new 2026-04-03 session.
* Added the new session to the English sessions list in the `sidebars/videos.js` sidebar configuration.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
