### PR TITLE
chore: add 2026-03-26 video

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   },
   "repository": "git@github.com:dragonflyoss/d7y.io.git",
   "resolutions": {
-    "cheerio": "<1.0.0"
+    "cheerio": "<1.0.0",
+    "webpackbar": "^7.0.0"
   },
   "engines": {
     "node": ">=18.0"

--- a/sidebars/videos.js
+++ b/sidebars/videos.js
@@ -11,6 +11,7 @@ module.exports = {
           collapsed: false,
           items: [
             'sessions/en/2026-04-03',
+            'sessions/en/2026-03-26',
             'sessions/en/2025-11-13',
             'sessions/en/2024-03-23',
             'sessions/en/2023-05-02',

--- a/videos/sessions/en/2026-03-26.md
+++ b/videos/sessions/en/2026-03-26.md
@@ -1,0 +1,20 @@
+---
+title: Dragonfly v2.4.0 - Intro, Updates, Data Distribution in AI Infrastructure
+---
+
+Speakers: [Wenbo Qi](https://github.com/gaius-qi)
+
+> This video is posted in 2024-03-26.
+
+Dragonfly provides efficient, stable, and secure file distribution and image acceleration using P2P technology
+within cloud-native architectures. This talk will briefly introduce Dragonfly and highlight the features of
+its latest version. Key updates include enhanced security and new functionalities tailored for more efficient
+and robust model distribution. We will also demonstrate how Dragonfly preheats and distributes AI
+models (packaged as OCI Artifacts) to read-only volumes in Kubernetes, enabling faster deployments. Additionally, we
+will introduce P2P-based state snapshot and restore capabilities in AI agent scenarios.
+
+<!-- markdownlint-disable -->
+
+<iframe width="720" height="480" src="https://www.youtube.com/embed/zjCFSEVvaX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen> </iframe>
+
+<!-- markdownlint-restore -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new video session entry for March 26, 2026, focused on Dragonfly v2.4.0, to the videos documentation. The sidebar is updated to include this new session, and a corresponding markdown file with session details and an embedded video is introduced.

New video session addition:

* Added a new session entry, `sessions/en/2026-03-26`, to the sidebar configuration in `sidebars/videos.js`, making it accessible from the documentation navigation.
* Created a new markdown file, `videos/sessions/en/2026-03-26.md`, containing the session's title, speaker information, summary of the talk, and an embedded YouTube video. The session covers updates in Dragonfly v2.4.0 and its applications in AI infrastructure.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
