### PR TITLE
docs: add preheat file and image for dfctl

### DIFF
--- a/docs/reference/commands/client/dfctl.md
+++ b/docs/reference/commands/client/dfctl.md
@@ -23,6 +23,22 @@ Delete a task in client's local storage.
 dfctl task rm <ID>
 ```
 
+Preheat a file task.
+
+```shell
+dfctl task preheat http://example.com/file.txt --scheduler-endpoint http://scheduler-service:8002
+```
+
+<!-- markdownlint-disable -->
+
+Preheat a image task.
+
+```shell
+dfctl task preheat oci://docker.io/library/nginx:latest --scheduler-endpoint http://scheduler-service:8002 --username <USERNAME>  --password <PASSWORD>
+```
+
+<!-- markdownlint-restore -->
+
 ### Persistent Task
 
 List all persistent tasks in client's local storage.

--- a/docs/reference/commands/client/dfget.md
+++ b/docs/reference/commands/client/dfget.md
@@ -76,10 +76,10 @@ Once set up, use the dfget command with the `--transfer-from-dfdaemon` flag to d
 dfget --transfer-from-dfdaemon https://<host>:<port>/<path> -O /tmp/file.txt
 ```
 
-`--transfer-from-dfdaemon` specify whether to transfer the content of downloading file from dfdaemon's unix domain socket. If it is `true`,
-dfget will call dfdaemon to download the file, and dfdaemon will return the content of downloading file to
-dfget via unix domain socket, and dfget will copy the content to the output path. If it is `false`, dfdaemon will
-download the file and hardlink or copy the file to the output path.
+`--transfer-from-dfdaemon` specify whether to transfer the content of downloading file from dfdaemon's unix domain
+socket. If it is `true`, dfget will call dfdaemon to download the file, and dfdaemon will return the content
+of downloading file to dfget via unix domain socket, and dfget will copy the content to the output path.
+If it is `false`, dfdaemon will download the file and hardlink or copy the file to the output path.
 
 ### Download with different protocols {#download-with-different-protocols}
 
@@ -121,6 +121,8 @@ dfget abs://<container>/<path> -O /tmp/path/ --recursive --storage-access-key-id
 
 #### Download with OSS protocol
 
+<!-- markdownlint-disable -->
+
 ```shell
 # Download a file.
 dfget oss://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
@@ -129,7 +131,11 @@ dfget oss://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key
 dfget oss://<bucket>/<path> -O /tmp/path/ --recursive --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
 ```
 
+<!-- markdownlint-restore -->
+
 #### Download with OBS protocol
+
+<!-- markdownlint-disable -->
 
 ```shell
 # Download a file.
@@ -139,9 +145,13 @@ dfget obs://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key
 dfget obs://<bucket>/<path> -O /tmp/path/ --recursive --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
 ```
 
+<!-- markdownlint-restore -->
+
 #### Download with COS protocol
 
 > Note: The endpoint does not require `BucketName-APPID`, just --storage-endpoint=cos.region.myqcloud.com.
+
+<!-- markdownlint-disable -->
 
 ```shell
 # Download a file.
@@ -151,6 +161,8 @@ dfget cos://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key
 dfget cos://<bucket>/<path> -O /tmp/path/ --recursive --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret> --storage-endpoint=<endpoint>
 ```
 
+<!-- markdownlint-restore -->
+
 #### Download with HDFS protocol
 
 ```shell
@@ -158,6 +170,8 @@ dfget hdfs://<path>/file.txt -O /tmp/file.txt  --hdfs-delegation-token <hadoop_d
 ```
 
 #### Download with Hugging Face protocol
+
+<!-- markdownlint-disable -->
 
 ```shell
 # Download a single file from a model repository.
@@ -176,7 +190,11 @@ $ dfget hf://<owner>/<repo> --hf-revision main -O /tmp/repo/ -r
 dfget hf://datasets/<owner>/<repo>/<path> -O /tmp/train.json
 ```
 
+<!-- markdownlint-restore -->
+
 #### Download with ModelScope protocol
+
+<!-- markdownlint-disable -->
 
 ```shell
 # Download a single file from a model repository.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation for the `dfctl` and `dfget` client commands, mainly by adding new usage examples and improving formatting for clarity. The most notable changes are the addition of preheat task examples for `dfctl`, expanded protocol-specific download examples for `dfget`, and the use of markdownlint directives to improve code block formatting.

**New usage examples and documentation improvements:**

* Added examples for preheating file and image tasks using `dfctl task preheat`, including usage of scheduler endpoint and authentication flags.
* Expanded `dfget` documentation with example commands for downloading files using various protocols (OSS, OBS, COS, HDFS, Hugging Face, ModelScope), each with protocol-specific options. [[1]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R124-R125) [[2]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R134-R139) [[3]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R148-R155) [[4]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R164-R165) [[5]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R174-R175) [[6]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R193-R198)

**Formatting and clarity improvements:**

* Added markdownlint disable/restore directives around code blocks to ensure proper formatting in the rendered documentation. [[1]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R124-R125) [[2]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R134-R139) [[3]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R148-R155) [[4]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R164-R165) [[5]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R174-R175) [[6]](diffhunk://#diff-2c6527ed01304cd02cd912e5337cd4011a7de97f29b521694d1b13113b3eb3a3R193-R198)
* Improved the explanation of the `--transfer-from-dfdaemon` flag in the `dfget` documentation for better readability.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
