### PR TITLE
docs: replace seedPeer.clusterID with host.schedulerClusterID

### DIFF
--- a/docs/development-guide/configure-development-environment.md
+++ b/docs/development-guide/configure-development-environment.md
@@ -147,12 +147,13 @@ Configuration content is as follows:
 
 ```yaml
 # Seed Peer configuration.
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://127.0.0.1:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 ```
 
 Run Dfdaemon as Seed Peer:

--- a/docs/getting-started/installation/binaries.md
+++ b/docs/getting-started/installation/binaries.md
@@ -145,12 +145,13 @@ refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.md).
 
 ```shell
 # Seed Peer configuration.
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://dragonfly-manager:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 ```
 
 ##### Option 2: Setup Dfdaemon as Peer {#setup-dfdaemon-as-peer-rpm}
@@ -226,12 +227,13 @@ refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.md).
 
 ```shell
 # Seed Peer configuration.
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://dragonfly-manager:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 ```
 
 ##### Option 2: Setup Dfdaemon as Peer {#setup-dfdaemon-as-peer-deb}
@@ -395,12 +397,13 @@ Configuration content is as follows:
 
 ```yaml
 # Seed Peer configuration.
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://dragonfly-manager:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 ```
 
 Run Dfdaemon as Seed Peer:

--- a/docs/operations/integrations/container-runtime/containerd.md
+++ b/docs/operations/integrations/container-runtime/containerd.md
@@ -574,12 +574,13 @@ Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`,
 refer to [dfdaemon config](../../../reference/configuration/client/dfdaemon.md).
 
 ```shell
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://dragonfly-manager:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 proxy:
   registryMirror:
     # addr is the default address of the registry mirror. Proxy will start a registry mirror service for the

--- a/docs/operations/integrations/container-runtime/cri-o.md
+++ b/docs/operations/integrations/container-runtime/cri-o.md
@@ -396,12 +396,13 @@ Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`,
 refer to [dfdaemon config](../../../reference/configuration/client/dfdaemon.md).
 
 ```shell
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://dragonfly-manager:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 proxy:
   registryMirror:
     # addr is the default address of the registry mirror. Proxy will start a registry mirror service for the

--- a/docs/operations/integrations/container-runtime/podman.md
+++ b/docs/operations/integrations/container-runtime/podman.md
@@ -396,12 +396,13 @@ Configure `dfdaemon.yaml`, the default path is `/etc/dragonfly/dfdaemon.yaml`,
 refer to [dfdaemon config](../../../reference/configuration/client/dfdaemon.md).
 
 ```shell
+host:
+  schedulerClusterID: 1
 manager:
   addr: http://dragonfly-manager:65003
 seedPeer:
   enable: true
   type: super
-  clusterID: 1
 proxy:
   registryMirror:
     # addr is the default address of the registry mirror. Proxy will start a registry mirror service for the


### PR DESCRIPTION
## Summary

- Replace the stale `seedPeer.clusterID: 1` config with `host.schedulerClusterID: 1` across all installation, container-runtime integration, and development-guide pages.
- The Rust client dropped `SeedPeer.cluster_id` and the `ManagerAnnouncer` in [dragonflyoss/client#1261](https://github.com/dragonflyoss/client/pull/1261) (shipped v1.0.11, 2025-08-19). Cluster membership now travels via `host.schedulerClusterID` ([dragonflyoss/client#1240](https://github.com/dragonflyoss/client/pull/1240)).
- Extends [#317](https://github.com/dragonflyoss/d7y.io/pull/317) (which only updated `docs/reference/configuration/client/dfdaemon.md`) to the five remaining files that still carried the stale snippet.

## Affected files

| File | Sites fixed |
|---|---|
| `docs/getting-started/installation/binaries.md` | 3 (RPM, DEB, generic Seed Peer sections) |
| `docs/development-guide/configure-development-environment.md` | 1 |
| `docs/operations/integrations/container-runtime/containerd.md` | 1 |
| `docs/operations/integrations/container-runtime/cri-o.md` | 1 |
| `docs/operations/integrations/container-runtime/podman.md` | 1 |

## Why this matters

Serde's default behavior silently ignores unknown YAML fields, so anyone following the current docs on client v1.0.11+ gets no error — the `clusterID` setting is silently discarded and the seed peer lands in the default cluster. This has been the case for ~8 months (since v1.0.11, 2025-08-19).

## Related

- dragonflyoss/client#1240 — added `host.schedulerClusterID`
- dragonflyoss/client#1261 — removed `SeedPeer.cluster_id` + `ManagerAnnouncer`
- dragonflyoss/dragonfly#4235 — scheduler refactor that made the announcement redundant
- #317 — partial doc fix (reference config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)