### PR TITLE
docs: add maxRetries for client config

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -336,6 +336,10 @@ health:
 backend:
   # requestHeader is the user customized request header which will be applied to the request when proxying to the origin server.
   requestHeader: {}
+  # The maximum number of retry attempts when a chunk request to the backend
+  # storage fails. Once this limit is reached, the request will be considered
+  # failed and an error will be returned.
+  maxRetries: 1
   # enableCacheTemporaryRedirect enables caching of 307 redirect URLs.
   #
   # Motivation: Dragonfly splits a download URL into multiple pieces and performs multiple


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds a new configuration option to the `dfdaemon` client documentation to improve backend request reliability.

Backend request reliability:

* Added a `maxRetries` option under the `backend` section, allowing users to configure the maximum number of retry attempts when a chunk request to the backend storage fails. If this limit is reached, the request is marked as failed and an error is returned.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
