### PR TITLE
feat(manager+scheduler): add ExternalRedis TLS support (related to is…

### DIFF
--- a/docs/reference/configuration/manager.md
+++ b/docs/reference/configuration/manager.md
@@ -150,6 +150,17 @@ database:
     brokerDB: 1
     # Redis backend DB.
     backendDB: 2
+  # # Redis TLS client configuration.
+  # tls:
+  #   # caCert is the CA certificate file path for Redis TLS handshake.
+  #   caCert: /etc/dragonfly/redis/ca.crt
+  #   # cert is the client certificate file path for Redis mTLS handshake.
+  #   cert: /etc/dragonfly/redis/tls.crt
+  #   # key is the client key file path for Redis mTLS handshake.
+  #   key: /etc/dragonfly/redis/tls.key
+  #   # insecureSkipVerify controls whether the client verifies the server's
+  #   # certificate chain and hostname.
+  #   insecureSkipVerify: false
 
 # Manager server cache.
 cache:

--- a/docs/reference/configuration/scheduler.md
+++ b/docs/reference/configuration/scheduler.md
@@ -119,6 +119,17 @@ database:
     brokerDB: 1
     # Redis backend DB.
     backendDB: 2
+  # # Redis TLS client configuration.
+  # tls:
+  #   # caCert is the CA certificate file path for Redis TLS handshake.
+  #   caCert: /etc/dragonfly/redis/ca.crt
+  #   # cert is the client certificate file path for Redis mTLS handshake.
+  #   cert: /etc/dragonfly/redis/tls.crt
+  #   # key is the client key file path for Redis mTLS handshake.
+  #   key: /etc/dragonfly/redis/tls.key
+  #   # insecureSkipVerify controls whether the client verifies the server's
+  #   # certificate chain and hostname.
+  #   insecureSkipVerify: false
 
 # Dynamic data configuration.
 dynConfig:


### PR DESCRIPTION
Follow-up to dragonflyoss/dragonfly#4738. Adds commented-out tls block to the database.redis section of both the manager and scheduler configuration reference docs, documenting the three supported shapes:

insecureSkipVerify: true — trust-on-first-use / managed Redis (ElastiCache, Azure Cache, Memorystore)
caCert only — server-side TLS
caCert + cert + key — mutual TLS