### PR TITLE
Pod doesn't have the label `release`

### DIFF
--- a/docs/operations/integrations/container-runtime/containerd.md
+++ b/docs/operations/integrations/container-runtime/containerd.md
@@ -172,7 +172,7 @@ You can execute the following command to check if the `alpine:3.19` image is dis
 
 ```shell
 # Find pod name.
-export POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,release=dragonfly,component=client" -o=jsonpath='{.items[?(@.spec.nodeName=="kind-worker")].metadata.name}' | head -n 1 )
+export POD_NAME=$(kubectl get pods --namespace dragonfly-system -l "app=dragonfly,component=client" -o=jsonpath='{.items[?(@.spec.nodeName=="kind-worker")].metadata.name}' | head -n 1 )
 
 # Find peer id.
 export TASK_ID=$(kubectl -n dragonfly-system exec ${POD_NAME} -- sh -c "grep -hoP 'library/alpine.*task_id=\"\K[^\"]+' /var/log/dragonfly/dfdaemon/* | head -n 1")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The screenshot is the labels of a Dragonfly client Pod.

<img width="532" height="79" alt="image" src="https://github.com/user-attachments/assets/f71023ef-952c-4b6a-94c4-4d83ff26f7a6" />


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
