### PR TITLE
docs: fix typos across documentation

### DIFF
--- a/blog/2023-09-01-using-dragonfly-to-distribute-images-and-files-for-multi-cluster-kuberenetes/index.md
+++ b/blog/2023-09-01-using-dragonfly-to-distribute-images-and-files-for-multi-cluster-kuberenetes/index.md
@@ -242,7 +242,7 @@ Create dragonfly cluster B record successfully.
 
 ### Use scopes to distinguish different dragonfly clusters
 
-The dragonfly cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope. The scopes of the dragonfly cluster are configured when the console is created and updated. The scopes of the peer are configured in peer YAML config, the fields are host.idc, host.location and host.advertiseIP, refer to [dfdaemon config](https://d7y.io/docs/next/reference/configuration/dfdaemon).
+The dragonfly cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope. The scopes of the dragonfly cluster are configured when the console is created and updated. The scopes of the peer are configured in peer YAML config, the fields are host.idc, host.location and host.advertiseIP, refer to [dfdaemon config](https://d7y.io/docs/next/reference/configuration/dfdaemon).
 
 If the peer scopes match the dragonfly cluster scopes, then the peer will use the dragonfly cluster’s scheduler and seed peer first, and if there is no matching dragonfly cluster then use the default dragonfly cluster.
 

--- a/docs/advanced-guides/web-console/cluster.md
+++ b/docs/advanced-guides/web-console/cluster.md
@@ -34,7 +34,7 @@ the default cluster will be used.
 
 ### Scopes
 
-The cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope.
+The cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope.
 
 **Location**: The cluster needs to serve all peers in the location. When the location in the peer configuration matches
 the location in the cluster, the peer will preferentially use the scheduler and the seed peer of the cluster.

--- a/docs/development-guide/system-design.md
+++ b/docs/development-guide/system-design.md
@@ -67,7 +67,7 @@ to [Architecture](./../operations/architecture/architecture.md).
 
 ![peer-state](./../resource/development-guide/system-design/peer-state.png)
 
-The process of interaction between Deamon and Scheduler when downloading a file is divided into 4 stages, and each stage corresponds to a gRPC interface on Scheduler.
+The process of interaction between Daemon and Scheduler when downloading a file is divided into 4 stages, and each stage corresponds to a gRPC interface on Scheduler.
 
 - registerPeerTask registration:
   - When starting to download, Peer first registers its current Task with Scheduler. Scheduler will create a new PeerTask for this registration and maintain it in memory. If this PeerTask is the first time this Task is created, then Scheduler will initiate a back-to-source download request to SeedPeer node. There is a detail here. Scheduler will behave differently according to the size of the file to be downloaded. If the file is too small, then Scheduler will find a Peer to download the file back and return all the data directly when registering.

--- a/versioned_docs/version-v2.1.0/reference/manage-console.md
+++ b/versioned_docs/version-v2.1.0/reference/manage-console.md
@@ -43,7 +43,7 @@ the default cluster will be used.
 
 ### Scopes
 
-The cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope.
+The cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope.
 
 **Location**: The cluster needs to serve all peers in the location. When the location in the peer configuration matches
 the location in the cluster, the peer will preferentially use the scheduler and the seed peer of the cluster.

--- a/versioned_docs/version-v2.1.x/getting-started/quick-start/multi-cluster-kubernetes.md
+++ b/versioned_docs/version-v2.1.x/getting-started/quick-start/multi-cluster-kubernetes.md
@@ -274,7 +274,7 @@ Create Dragonfly cluster B record successfully.
 
 ### Use scopes to distinguish different Dragonfly clusters
 
-The Dragonfly cluster needs to serve the scope. It wil provide scheduler services and
+The Dragonfly cluster needs to serve the scope. It will provide scheduler services and
 seed peer services to peers in the scope. The scopes of the Dragonfly cluster are configured
 when the console is created and updated. The scopes of the peer are configured in peer YAML config,
 the fields are `host.idc`, `host.location` and `host.advertiseIP`,

--- a/versioned_docs/version-v2.1.x/reference/manage-console.md
+++ b/versioned_docs/version-v2.1.x/reference/manage-console.md
@@ -43,7 +43,7 @@ the default cluster will be used.
 
 ### Scopes
 
-The cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope.
+The cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope.
 
 **Location**: The cluster needs to serve all peers in the location. When the location in the peer configuration matches
 the location in the cluster, the peer will preferentially use the scheduler and the seed peer of the cluster.

--- a/versioned_docs/version-v2.2.0/advanced-guides/web-console/cluster.md
+++ b/versioned_docs/version-v2.2.0/advanced-guides/web-console/cluster.md
@@ -34,7 +34,7 @@ the default cluster will be used.
 
 ### Scopes
 
-The cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope.
+The cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope.
 
 **Location**: The cluster needs to serve all peers in the location. When the location in the peer configuration matches
 the location in the cluster, the peer will preferentially use the scheduler and the seed peer of the cluster.

--- a/versioned_docs/version-v2.2.0/getting-started/quick-start/multi-cluster-kubernetes.md
+++ b/versioned_docs/version-v2.2.0/getting-started/quick-start/multi-cluster-kubernetes.md
@@ -266,7 +266,7 @@ Create Dragonfly cluster B record successfully.
 
 ### Use scopes to distinguish different Dragonfly clusters
 
-The Dragonfly cluster needs to serve the scope. It wil provide scheduler services and
+The Dragonfly cluster needs to serve the scope. It will provide scheduler services and
 seed peer services to peers in the scope. The scopes of the Dragonfly cluster are configured
 when the console is created and updated. The scopes of the peer are configured in peer YAML config,
 the fields are `host.idc`, `host.location` and `host.advertiseIP`,

--- a/versioned_docs/version-v2.3.0/advanced-guides/web-console/cluster.md
+++ b/versioned_docs/version-v2.3.0/advanced-guides/web-console/cluster.md
@@ -34,7 +34,7 @@ the default cluster will be used.
 
 ### Scopes
 
-The cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope.
+The cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope.
 
 **Location**: The cluster needs to serve all peers in the location. When the location in the peer configuration matches
 the location in the cluster, the peer will preferentially use the scheduler and the seed peer of the cluster.

--- a/versioned_docs/version-v2.3.0/getting-started/quick-start/multi-cluster-kubernetes.md
+++ b/versioned_docs/version-v2.3.0/getting-started/quick-start/multi-cluster-kubernetes.md
@@ -256,7 +256,7 @@ Create Dragonfly cluster B record successfully.
 
 ### Use scopes to distinguish different Dragonfly clusters
 
-The Dragonfly cluster needs to serve the scope. It wil provide scheduler services and
+The Dragonfly cluster needs to serve the scope. It will provide scheduler services and
 seed peer services to peers in the scope. The scopes of the Dragonfly cluster are configured
 when the console is created and updated. The scopes of the peer are configured in peer YAML config,
 the fields are `host.idc`, `host.location` and `host.advertiseIP`,

--- a/versioned_docs/version-v2.4.0/advanced-guides/web-console/cluster.md
+++ b/versioned_docs/version-v2.4.0/advanced-guides/web-console/cluster.md
@@ -34,7 +34,7 @@ the default cluster will be used.
 
 ### Scopes
 
-The cluster needs to serve the scope. It wil provide scheduler services and seed peer services to peers in the scope.
+The cluster needs to serve the scope. It will provide scheduler services and seed peer services to peers in the scope.
 
 **Location**: The cluster needs to serve all peers in the location. When the location in the peer configuration matches
 the location in the cluster, the peer will preferentially use the scheduler and the seed peer of the cluster.

--- a/versioned_docs/version-v2.4.0/development-guide/system-design.md
+++ b/versioned_docs/version-v2.4.0/development-guide/system-design.md
@@ -67,7 +67,7 @@ to [Architecture](./../operations/deployment/architecture.md).
 
 ![peer-state](./../resource/development-guide/system-design/peer-state.png)
 
-The process of interaction between Deamon and Scheduler when downloading a file is divided into 4 stages, and each stage corresponds to a gRPC interface on Scheduler.
+The process of interaction between Daemon and Scheduler when downloading a file is divided into 4 stages, and each stage corresponds to a gRPC interface on Scheduler.
 
 - registerPeerTask registration:
   - When starting to download, Peer first registers its current Task with Scheduler. Scheduler will create a new PeerTask for this registration and maintain it in memory. If this PeerTask is the first time this Task is created, then Scheduler will initiate a back-to-source download request to SeedPeer node. There is a detail here. Scheduler will behave differently according to the size of the file to be downloaded. If the file is too small, then Scheduler will find a Peer to download the file back and return all the data directly when registering.

--- a/versioned_docs/version-v2.4.0/getting-started/quick-start/multi-cluster-kubernetes.md
+++ b/versioned_docs/version-v2.4.0/getting-started/quick-start/multi-cluster-kubernetes.md
@@ -601,7 +601,7 @@ Create Dragonfly cluster B record successfully.
 
 #### Use scopes to distinguish different Dragonfly clusters
 
-The Dragonfly cluster needs to serve the scope. It wil provide scheduler services and
+The Dragonfly cluster needs to serve the scope. It will provide scheduler services and
 seed peer services to peers in the scope. The scopes of the Dragonfly cluster are configured
 when the console is created and updated. The scopes of the peer are configured in peer YAML config,
 the fields are `host.idc`, `host.location` and `host.advertiseIP`,


### PR DESCRIPTION
Noticed a couple typos while going through the docs:
- `Deamon` → `Daemon` in system-design.md
- `wil` → `will` in cluster docs and multi-cluster quickstart guides

Fixes span current docs and versioned docs.
