### PR TITLE
docs: add Skills / Agent Capabilities for roadmap 2.6

### DIFF
--- a/docs/roadmap/v2.6.md
+++ b/docs/roadmap/v2.6.md
@@ -37,7 +37,6 @@ for release on December 31, 2026.
 - Ensure data reliability when asynchronously writing to object storage.
 - Implement Python SDK to support snapshotter for use in AI agent.
 - Explore integrating the Agent Sandbox, Gymnasium, etc.
-- Implement model context protocol (MCP).
 
 ## Others
 
@@ -53,6 +52,10 @@ for release on December 31, 2026.
 ### Testing
 
 - Add more E2E tests and unit tests.
+
+### Skills / Agent Capabilities
+
+- Add a Dragonfly skill to enable troubleshooting and diagnosis capabilities.
 
 ## Documentation
 
@@ -86,3 +89,7 @@ for release on December 31, 2026.
 ### Kata Container Support
 
 - Best practice documentation for using nydus in Kata Container scenarios.
+
+### Skills / Agent Capabilities {#nydus-skills}
+
+- Add a Dragonfly skill to enable troubleshooting and diagnosis capabilities.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the v2.6 roadmap documentation to clarify and expand on planned features, especially around agent skills and capabilities. The most notable changes are the introduction of a new Dragonfly skill for troubleshooting and diagnosis, and some cleanup of the listed protocols.

Agent Skills and Capabilities:

* Added a new section under "Skills / Agent Capabilities" describing the addition of a Dragonfly skill to enable troubleshooting and diagnosis for agents.
* Added a similar "Skills / Agent Capabilities" section specifically under "Kata Container Support" to highlight the Dragonfly skill in that context.

Roadmap Cleanup:

* Removed the item to "Implement model context protocol (MCP)" from the general roadmap list.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
