### PR TITLE
docs: add namespace-level injection and config reference

### DIFF
--- a/docs/getting-started/installation/helm-charts.md
+++ b/docs/getting-started/installation/helm-charts.md
@@ -451,6 +451,7 @@ Init Containers:
       /usr/local/bin/dfget
       /usr/local/bin/dfcache
       /usr/local/bin/dfstore
+      /usr/local/bin/dfctl
       /usr/local/bin/dfdaemon
       -t
       /dragonfly/bin/
@@ -513,12 +514,56 @@ Verify that the Dragonfly binaries are available inside the container:
 
 ```shell
 $ kubectl exec -it test-pod -- bash
-$ which dfget dfcache dfstore dfdaemon
+$ which dfget dfcache dfstore dfctl dfdaemon
 /usr/local/bin/dfget
 /usr/local/bin/dfcache
 /usr/local/bin/dfstore
+/usr/local/bin/dfctl
 /usr/local/bin/dfdaemon
 ```
+
+#### Namespace-level injection {#namespace-level-injection}
+
+Instead of annotating each Pod individually, you can label a namespace to inject all Pods created in it:
+
+```shell
+kubectl label namespace default dragonfly.io/inject=true
+```
+
+Any Pod created in that namespace will get the Dragonfly binaries and unix socket injected automatically.
+If a Pod also has the `dragonfly.io/inject` annotation, the annotation takes priority over the namespace label.
+
+To disable injection for a specific Pod in a labeled namespace, set the annotation to `false`:
+
+```yaml
+metadata:
+  annotations:
+    dragonfly.io/inject: 'false'
+```
+
+#### Injector configuration reference {#injector-configuration-reference}
+
+The injector reads its config from a ConfigMap mounted at `/etc/dragonfly/injector.yaml`.
+When deployed via Helm, this is the `injector.initContainerImage` section in `values.yaml`.
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `initContainerImage.registry` | Container registry | `docker.io` |
+| `initContainerImage.repository` | Image repository | `dragonflyoss/client` |
+| `initContainerImage.tag` | Image tag | `latest` |
+| `initContainerImage.digest` | Image digest (overrides tag if set) | `""` |
+| `initContainerImage.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `initContainerImage.pullSecrets` | Image pull secrets | `[]` |
+
+The injector reloads this config every 30 seconds. Changes to the ConfigMap take effect without restarting the injector Pod.
+
+Per-Pod annotations:
+
+| Annotation | Description |
+| --- | --- |
+| `dragonfly.io/inject` | Set to `true` to inject a Pod (or `false` to skip in a labeled namespace) |
+| `dragonfly.io/init-container-image` | Override the init container image for this Pod |
+| `dragonfly.io/skip-unix-sock-inject` | Set to `true` to skip dfdaemon unix socket mount |
 
 #### Download files using dfget {#download-files-using-dfget}
 

--- a/docs/operations/integrations/injector.md
+++ b/docs/operations/integrations/injector.md
@@ -1,0 +1,116 @@
+---
+id: injector
+title: Webhook Injector
+slug: /operations/integrations/injector/
+---
+
+The Dragonfly webhook injector is a Kubernetes mutating admission webhook that automatically
+injects Dragonfly client binaries and the dfdaemon unix socket into application Pods. This
+means your container images don't need to bundle Dragonfly tools — the injector handles it
+at Pod creation time.
+
+## When to use it
+
+Use the injector when you want Pods to have access to `dfget`, `dfcache`, `dfstore`, `dfctl`,
+and `dfdaemon` without modifying the container image. Typical use cases:
+
+- Pull artifacts through Dragonfly's P2P network from inside a running Pod
+- Use `dfget` for large file downloads in CI/CD jobs or data pipelines
+- Access the dfdaemon unix socket for proxy-based P2P transfers
+
+## Prerequisites
+
+- A running Dragonfly cluster (manager, scheduler, seed client, client)
+- [cert-manager](https://cert-manager.io/) for webhook TLS certificates
+
+## Install via Helm (recommended)
+
+If you use the Dragonfly Helm chart, enable the injector in your `values.yaml`:
+
+```yaml
+injector:
+  enable: true
+  replicas: 2
+  image:
+    registry: docker.io
+    repository: dragonflyoss/injector
+    tag: latest
+  initContainerImage:
+    registry: docker.io
+    repository: dragonflyoss/client
+    tag: latest
+  certManager:
+    enable: true
+    issuer:
+      name: ''
+      kind: Issuer
+      create: true
+```
+
+See the [Helm Charts installation guide](../../getting-started/installation/helm-charts.md#using-dragonfly-with-webhook-injection) for the full walkthrough.
+
+## Install via manifests
+
+For standalone deployment without Helm:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/dragonflyoss/dragonfly-injector/main/dist/install.yaml
+```
+
+This creates the injector deployment, webhook configuration, RBAC, and a default ConfigMap
+in the `dragonfly-system` namespace.
+
+To customize the injector config after install:
+
+```shell
+kubectl -n dragonfly-system edit configmap dragonfly-injector-config
+```
+
+## How injection works
+
+The injector watches for Pod create/update requests and mutates the Pod spec when injection
+is enabled. It adds:
+
+1. An init container that copies Dragonfly binaries (`dfget`, `dfcache`, `dfstore`, `dfctl`, `dfdaemon`) into a shared volume
+2. Volume mounts so each container can access the binaries at `/usr/local/bin/`
+3. A hostPath volume mount for the dfdaemon unix socket at `/var/run/dragonfly/dfdaemon.sock`
+
+## Enabling injection
+
+**Per namespace** — label the namespace:
+
+```shell
+kubectl label namespace my-namespace dragonfly.io/inject=true
+```
+
+**Per pod** — annotate the Pod:
+
+```yaml
+metadata:
+  annotations:
+    dragonfly.io/inject: 'true'
+```
+
+If both are set, the Pod annotation takes priority.
+
+## Annotations reference
+
+| Annotation | Description |
+| --- | --- |
+| `dragonfly.io/inject` | `true` to inject, `false` to skip |
+| `dragonfly.io/init-container-image` | Override the init container image for this Pod |
+| `dragonfly.io/skip-unix-sock-inject` | `true` to skip the dfdaemon socket mount |
+
+## Troubleshooting
+
+Check the injector logs:
+
+```shell
+kubectl -n dragonfly-system logs -l app.kubernetes.io/name=dragonfly-injector
+```
+
+If Pods are not getting injected:
+
+- Verify the namespace label or pod annotation is set correctly
+- Check that cert-manager issued the webhook certificate
+- Check that the `MutatingWebhookConfiguration` exists: `kubectl get mutatingwebhookconfigurations`


### PR DESCRIPTION
The existing webhook injector docs only covered per-pod annotations. Added a few things that were missing:

- namespace-level injection via `dragonfly.io/inject` label (the code already supports this, just wasn't documented)
- config reference table for the injector ConfigMap fields
- per-pod annotation reference table
- updated the `kubectl describe` output and `which` check to include `dfctl` (added in dragonfly-injector#36)

Relates to dragonflyoss/dragonfly#4416
