### PR TITLE
feat: add adaptiveRateLimit config for client

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -30,6 +30,29 @@ server:
   pluginDir: /var/lib/dragonfly/plugins/dfdaemon/
   # cacheDir is the directory to store cache files.
   cacheDir: /var/cache/dragonfly/dfdaemon/
+  # BBR-inspired adaptive rate limiter configuration for gRPC servers (download & upload).
+  # When system CPU or memory usage exceeds the configured thresholds, the limiter
+  # estimates capacity via `max_pass × min_rt × bucket_count / 1000` and sheds
+  # incoming requests whose in-flight count exceeds this estimate. A cooldown
+  # period prevents rapid oscillation between shedding and accepting.
+  adaptiveRateLimit:
+    # Number of time buckets in the rolling window for metric aggregation.
+    bucketCount: 50
+    # Duration of each time bucket (e.g., 200ms).
+    bucketInterval: 200ms
+    # CPU usage percentage threshold (0–100) above which the system is
+    # considered overloaded. If threshold is 100, CPU usage is ignored
+    # for overload detection.
+    cpuThreshold: 100
+    # Memory usage percentage threshold (0–100) above which the system is
+    # considered overloaded. If threshold is 100, Memory usage is ignored
+    # for overload detection.
+    memoryThreshold: 90
+    # Duration to continue shedding incoming requests after the first drop
+    # event, preventing rapid oscillation between shedding and accepting.
+    shedCooldown: 5s
+    # How often the background task collects CPU/memory usage metrics.
+    collectInterval: 3s
 
 download:
   # protocol that peers use to download piece, supported values: "tcp", "quic".
@@ -47,13 +70,13 @@ download:
     # This limit applies to the total number of gRPC requests per second, including:
     # - Multiple requests within a single connection.
     # - Single requests across different connections.
-    requestRateLimit: 5000
+    requestRateLimit: 400
     # The buffer size for the request channel on the download gRPC server.
     #
     # This controls the capacity of the bounded channel used to queue
     # incoming gRPC requests before they are processed. If the buffer is full,
     # new requests will return a `RESOURCE_EXHAUSTED` error.
-    requestBufferSize: 1000
+    requestBufferSize: 50
   # bandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 50GB/s.
   bandwidthLimit: 50GB
   # backToSourceBandwidthLimit is the rate limit of the back to source speed in KB/MB/GB per second, default is 50GB/s.
@@ -83,13 +106,13 @@ upload:
     # This limit applies to the total number of gRPC requests per second, including:
     # - Multiple requests within a single connection.
     # - Single requests across different connections.
-    requestRateLimit: 5000
+    requestRateLimit: 400
     # The buffer size for the request channel on the upload gRPC server.
     #
     # This controls the capacity of the bounded channel used to queue
     # incoming gRPC requests before they are processed. If the buffer is full,
     # new requests will return a `RESOURCE_EXHAUSTED` error.
-    requestBufferSize: 1000
+    requestBufferSize: 50
 # # Client configuration for remote peer's upload server.
 # client:
 #   # CA certificate file path for mTLS.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `dfdaemon` client configuration documentation to introduce an adaptive rate limiter and to significantly lower the default gRPC request rate limits and buffer sizes for both download and upload servers. These changes are aimed at improving resource management and system stability under load.

**Adaptive rate limiting:**

* Added a new `adaptiveRateLimit` configuration section under `server` to enable BBR-inspired adaptive rate limiting for gRPC servers. This section includes settings for CPU and memory thresholds, bucketed metric aggregation, and a cooldown mechanism to prevent rapid oscillation between request shedding and acceptance.

**gRPC server resource limits:**

* Reduced the default `requestRateLimit` for both `download` and `upload` gRPC servers from 5000 to 400 requests per second to better protect system resources. [[1]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL50-R79) [[2]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL86-R115)
* Lowered the `requestBufferSize` for both `download` and `upload` gRPC servers from 1000 to 50, reducing the number of queued requests and improving responsiveness under high load. [[1]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL50-R79) [[2]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL86-R115)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
