### PR TITLE
chore: add Scarf analytics pixel to website footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -181,6 +181,8 @@ const config = {
         Copyright Dragonfly a Series of LF Projects, LLC.
         <br />
         For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">lfprojects.org/policies</a>.
+        <!-- Scarf analytics pixel for anonymous adoption metrics -->
+        <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c715dd71-d4a5-4994-88a4-c0d78eb1e8e7" />
       `,
     },
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a Scarf tracking pixel to the site-wide footer so the Dragonfly community can measure anonymous, aggregated documentation traffic and adoption trends across d7y.io.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
