### PR TITLE
docs(dfdaemon): add requestRateLimit config option to proxy server docs

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -257,6 +257,8 @@ proxy:
   server:
     # port is the port to the proxy server.
     port: 4001
+    # requestRateLimit is the rate limit of the proxy server, default is 400 req/s.
+    requestRateLimit: 400
   # # ip is the listen ip of the proxy server.
   # ip: ""
   # # caCert is the root CA cert path with PEM format for the proxy server to generate the server cert.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add `requestRateLimit` field to proxy server config docs
- Documents default value of 400 requests per second
- Placed under `proxy.server` section alongside existing `port` option
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
