### PR TITLE
Update buffer size defaults to 512KiB in documentation

### DIFF
--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -202,10 +202,10 @@ storage:
   dir: /var/lib/dragonfly/
   # keep indicates whether keep the task's metadata and content when the dfdaemon restarts.
   keep: true
-  # writeBufferSize is the buffer size for writing piece to disk, default is 4MiB.
-  writeBufferSize: 4194304
-  # readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
-  readBufferSize: 4194304
+  # writeBufferSize is the buffer size for writing piece to disk, default is 512KiB.
+  writeBufferSize: 524288
+  # readBufferSize is the buffer size for reading piece from disk, default is 512KiB.
+  readBufferSize: 524288
   # writePieceTimeout is the timeout for writing a piece to storage(e.g., disk or cache).
   writePieceTimeout: 360s
   server:
@@ -334,8 +334,8 @@ proxy:
   # prefetchBandwidthLimit is the rate limit of the prefetch speed in KB/MB/GB per second, default is 10GB/s.
   # The prefetch request has lower priority so limit the rate to avoid occupying the bandwidth impact other download tasks.
   prefetchBandwidthLimit: 10GB
-  # readBufferSize is the buffer size for reading piece from disk, default is 4MiB.
-  readBufferSize: 4194304
+  # readBufferSize is the buffer size for reading piece from disk, default is 512KiB.
+  readBufferSize: 524288
 
 metrics:
   server:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update `writeBufferSize` and `readBufferSize` defaults from 4MiB (4194304) to 512KiB (524288) in storage and proxy sections
- Align documentation comments with the new default values

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
