### PR TITLE
Add initial password configuration for DRAGONFLY

### DIFF
--- a/docs/advanced-guides/web-console/signin.md
+++ b/docs/advanced-guides/web-console/signin.md
@@ -9,3 +9,24 @@ The default username and password are `root` and `dragonfly`.
 > Note: It is strongly recommended that you change the default administrator password.
 
 ![signin](../../resource/advanced-guides/web-console/login//signin.png)
+
+## Customize the initial root password
+
+Set the `DRAGONFLY_INITIAL_ROOT_PASSWORD` environment variable of the manager to seed the root user
+with a custom password instead of the default one. The password must be between 8 and 20 characters.
+
+If you deploy Dragonfly with [Helm Charts](https://github.com/dragonflyoss/helm-charts), set it through
+`manager.extraEnvVars`, preferably referencing a Kubernetes secret:
+
+```yaml
+manager:
+  extraEnvVars:
+    - name: DRAGONFLY_INITIAL_ROOT_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: dragonfly-root-password
+          key: password
+```
+
+> Note: The environment variable only takes effect when the root user is created for the first time.
+> After that, the password is managed in the database and can be changed from the console.

--- a/docs/getting-started/quick-start/multi-cluster-kubernetes/deployment-with-manager.md
+++ b/docs/getting-started/quick-start/multi-cluster-kubernetes/deployment-with-manager.md
@@ -252,7 +252,8 @@ kubectl apply -f manager-rest-svc.yaml -n cluster-a
 #### Visit manager console {#visit-manager-console-simple}
 
 Visit address `localhost:8080` to see the manager console. Sign in the console with the default root user,
-the username is `root` and password is `dragonfly`.
+the username is `root` and password is `dragonfly`. To customize the initial password, refer to
+[Sign in](../../../advanced-guides/web-console/signin.md).
 
 ![signin](../../../resource/getting-started/signin.png)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation to clarify how to customize the initial root password for the Dragonfly web console and improves guidance around secure password setup.

Documentation improvements:

* Added a new section in `signin.md` describing how to set a custom initial root password via the `DRAGONFLY_INITIAL_ROOT_PASSWORD` environment variable, including an example for Helm deployments and important notes on when the variable takes effect.
* Updated the multi-cluster Kubernetes quick start guide to reference the new instructions for customizing the initial root password, enhancing discoverability for users.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/helm-charts/issues/505

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
