### PR TITLE
feat: add go-import vanity pages for dragonfly-sdk

### DIFF
--- a/static/dragonfly-sdk/client-request/go/index.html
+++ b/static/dragonfly-sdk/client-request/go/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta name="go-import" content="d7y.io/dragonfly-sdk git https://github.com/dragonflyoss/dragonfly-sdk" />
+  </head>
+  <body>
+    Welcome to Dragonfly SDK client-request for Go!
+  </body>
+</html>

--- a/static/dragonfly-sdk/index.html
+++ b/static/dragonfly-sdk/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta name="go-import" content="d7y.io/dragonfly-sdk git https://github.com/dragonflyoss/dragonfly-sdk" />
+  </head>
+  <body>
+    Welcome to Dragonfly SDK!
+  </body>
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds new HTML documentation pages for the Dragonfly SDK and its Go client-request module. These pages include the necessary `go-import` meta tags to support Go module resolution.

Documentation additions:

* Added `static/dragonfly-sdk/index.html` with a `go-import` meta tag for the main Dragonfly SDK Go module.
* Added `static/dragonfly-sdk/client-request/go/index.html` with a `go-import` meta tag for the client-request Go module.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
