### PR TITLE
docs: add stat_image usage for request-sdk

### DIFF
--- a/docs/advanced-guides/request-sdk.md
+++ b/docs/advanced-guides/request-sdk.md
@@ -45,8 +45,8 @@ For example, when Nydus downloads layer chunks via HTTP Range requests through K
 ## SDKs
 
 The SDKs are maintained in the [dragonfly-sdk](https://github.com/dragonflyoss/dragonfly-sdk) repository,
-sending requests to remote servers via the Dragonfly P2P network, supporting streaming and buffered GET requests
-and preheating files or OCI images through seed peers.
+sending requests to remote servers via the Dragonfly P2P network, supporting streaming and buffered GET requests,
+preheating files or OCI images through seed peers, and querying the distribution of OCI images in the seed peers.
 
 | Package                                                                                                        | Description                                                                                                            |
 | :------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
@@ -61,7 +61,7 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dragonfly-client-request = "1.6.0"
+dragonfly-client-request = "1.6.1"
 ```
 
 Send a GET request via the Dragonfly and process the response body as a stream:
@@ -159,11 +159,12 @@ let response = proxy_with_endpoints.get(&request).await?;
 ```
 
 The `preheat` feature enables preheating OCI images by resolving manifests from
-the registry and triggering seed peers to download each blob:
+the registry and triggering seed peers to download each blob, and querying the
+distribution of an OCI image with the layers cached by each seed peer:
 
 ```toml
 [dependencies]
-dragonfly-client-request = { version = "1.6.0", features = ["preheat"] }
+dragonfly-client-request = { version = "1.6.1", features = ["preheat"] }
 ```
 
 ```rust
@@ -175,6 +176,37 @@ proxy
         ..Default::default()
     })
     .await?;
+```
+
+Query the distribution of an OCI image, listing the layers cached by each
+seed peer, such as verifying a preheat:
+
+```rust
+use dragonfly_client_request::StatImageRequest;
+
+let response = proxy
+    .stat_image(&StatImageRequest {
+        image: "docker.io/library/nginx:latest".to_string(),
+        ..Default::default()
+    })
+    .await?;
+
+println!("image has {} layers", response.layers.len());
+for peer in response.peers.iter() {
+    let finished = peer
+        .cached_layers
+        .iter()
+        .filter(|layer| layer.is_finished)
+        .count();
+
+    println!(
+        "peer {} ({}) finished {} of {} cached layers",
+        peer.hostname,
+        peer.ip,
+        finished,
+        peer.cached_layers.len()
+    );
+}
 ```
 
 For more details, please refer to [dragonfly-client-request](https://crates.io/crates/dragonfly-client-request)
@@ -234,6 +266,28 @@ if err := proxy.Preheat(ctx, request.NewPreheatRequest("https://example.com/file
 
 if err := proxy.PreheatImage(ctx, request.NewPreheatImageRequest("docker.io/library/nginx:latest")); err != nil {
     panic(err)
+}
+```
+
+Query the distribution of an OCI image, listing the layers cached by each
+seed peer, such as verifying a preheat:
+
+```go
+resp, err := proxy.StatImage(ctx, request.NewStatImageRequest("docker.io/library/nginx:latest"))
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("image has %d layers\n", len(resp.Layers))
+for _, peer := range resp.Peers {
+    var finished int
+    for _, layer := range peer.CachedLayers {
+        if layer.IsFinished {
+            finished++
+        }
+    }
+
+    fmt.Printf("peer %s (%s) finished %d of %d cached layers\n", peer.Hostname, peer.IP, finished, len(peer.CachedLayers))
 }
 ```
 

--- a/versioned_docs/version-v2.5.0/advanced-guides/request-sdk.md
+++ b/versioned_docs/version-v2.5.0/advanced-guides/request-sdk.md
@@ -45,8 +45,8 @@ For example, when Nydus downloads layer chunks via HTTP Range requests through K
 ## SDKs
 
 The SDKs are maintained in the [dragonfly-sdk](https://github.com/dragonflyoss/dragonfly-sdk) repository,
-sending requests to remote servers via the Dragonfly P2P network, supporting streaming and buffered GET requests
-and preheating files or OCI images through seed peers.
+sending requests to remote servers via the Dragonfly P2P network, supporting streaming and buffered GET requests,
+preheating files or OCI images through seed peers, and querying the distribution of OCI images in the seed peers.
 
 | Package                                                                                                        | Description                                                                                                            |
 | :------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
@@ -61,7 +61,7 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dragonfly-client-request = "1.6.0"
+dragonfly-client-request = "1.6.1"
 ```
 
 Send a GET request via the Dragonfly and process the response body as a stream:
@@ -159,11 +159,12 @@ let response = proxy_with_endpoints.get(&request).await?;
 ```
 
 The `preheat` feature enables preheating OCI images by resolving manifests from
-the registry and triggering seed peers to download each blob:
+the registry and triggering seed peers to download each blob, and querying the
+distribution of an OCI image with the layers cached by each seed peer:
 
 ```toml
 [dependencies]
-dragonfly-client-request = { version = "1.6.0", features = ["preheat"] }
+dragonfly-client-request = { version = "1.6.1", features = ["preheat"] }
 ```
 
 ```rust
@@ -175,6 +176,37 @@ proxy
         ..Default::default()
     })
     .await?;
+```
+
+Query the distribution of an OCI image, listing the layers cached by each
+seed peer, such as verifying a preheat:
+
+```rust
+use dragonfly_client_request::StatImageRequest;
+
+let response = proxy
+    .stat_image(&StatImageRequest {
+        image: "docker.io/library/nginx:latest".to_string(),
+        ..Default::default()
+    })
+    .await?;
+
+println!("image has {} layers", response.layers.len());
+for peer in response.peers.iter() {
+    let finished = peer
+        .cached_layers
+        .iter()
+        .filter(|layer| layer.is_finished)
+        .count();
+
+    println!(
+        "peer {} ({}) finished {} of {} cached layers",
+        peer.hostname,
+        peer.ip,
+        finished,
+        peer.cached_layers.len()
+    );
+}
 ```
 
 For more details, please refer to [dragonfly-client-request](https://crates.io/crates/dragonfly-client-request)
@@ -234,6 +266,28 @@ if err := proxy.Preheat(ctx, request.NewPreheatRequest("https://example.com/file
 
 if err := proxy.PreheatImage(ctx, request.NewPreheatImageRequest("docker.io/library/nginx:latest")); err != nil {
     panic(err)
+}
+```
+
+Query the distribution of an OCI image, listing the layers cached by each
+seed peer, such as verifying a preheat:
+
+```go
+resp, err := proxy.StatImage(ctx, request.NewStatImageRequest("docker.io/library/nginx:latest"))
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("image has %d layers\n", len(resp.Layers))
+for _, peer := range resp.Peers {
+    var finished int
+    for _, layer := range peer.CachedLayers {
+        if layer.IsFinished {
+            finished++
+        }
+    }
+
+    fmt.Printf("peer %s (%s) finished %d of %d cached layers\n", peer.Hostname, peer.IP, finished, len(peer.CachedLayers))
 }
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation for the Dragonfly request SDKs to include a new feature for querying the distribution of OCI images across seed peers, and updates code samples to demonstrate this capability. It also bumps the documented Rust SDK version to `1.6.1` to reflect the new functionality.

**Feature documentation and code sample updates:**

* Added documentation and code examples (in both Rust and Go) for the new ability to query the distribution of OCI images, showing how to list layers cached by each seed peer and verify preheats. [[1]](diffhunk://#diff-283d1ccb559a831cf6179fea5ab259dcbd81079a8cf9c001f96b8c40d26b77c3R181-R211) [[2]](diffhunk://#diff-283d1ccb559a831cf6179fea5ab259dcbd81079a8cf9c001f96b8c40d26b77c3R272-R293)
* Updated the SDK feature description to mention support for querying OCI image distribution in addition to existing features.

**Version updates:**

* Updated Rust SDK version in all code samples and dependency instructions from `1.6.0` to `1.6.1` to reflect the new feature. [[1]](diffhunk://#diff-283d1ccb559a831cf6179fea5ab259dcbd81079a8cf9c001f96b8c40d26b77c3L64-R64) [[2]](diffhunk://#diff-283d1ccb559a831cf6179fea5ab259dcbd81079a8cf9c001f96b8c40d26b77c3L162-R167)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
