### PR TITLE
Specify containerd CRI plugin in documentation

### DIFF
--- a/docs/operations/integrations/container-runtime/containerd.md
+++ b/docs/operations/integrations/container-runtime/containerd.md
@@ -337,6 +337,52 @@ Restart containerd:
 systemctl restart containerd
 ```
 
+### Specify the containerd CRI plugin {#specify-the-containerd-cri-plugin}
+
+Dfinit writes the registry configuration under the CRI plugin table of `config.toml`. By default,
+dfinit uses the plugin table present in the containerd configuration, preferring
+`io.containerd.grpc.v1.cri` for version 2 configurations and `io.containerd.cri.v1.images` for
+version 3 configurations. This also covers version 2 configurations shipped with the containerd 2.x
+`io.containerd.cri.v1.images` plugin, e.g. AKS.
+
+If your containerd configuration contains both plugin tables, set `criPluginId` to override the
+detection. Deploy using Helm Charts and create the Helm Charts configuration file `values.yaml`.
+Please refer to the [configuration](https://artifacthub.io/packages/helm/dragonfly/dragonfly#values) documentation for details.
+
+```yaml
+scheduler:
+  image:
+    repository: dragonflyoss/scheduler
+    tag: latest
+  metrics:
+    enable: true
+
+seedClient:
+  image:
+    repository: dragonflyoss/client
+    tag: latest
+  metrics:
+    enable: true
+
+client:
+  image:
+    repository: dragonflyoss/client
+    tag: latest
+  metrics:
+    enable: true
+  dfinit:
+    enable: true
+    image:
+      repository: dragonflyoss/dfinit
+      tag: latest
+    config:
+      containerRuntime:
+        containerd:
+          configPath: /etc/containerd/config.toml
+          criPluginId: io.containerd.cri.v1.images
+          proxyAllRegistries: true
+```
+
 ### Private project {#private-project}
 
 Deploy using Helm Charts and create the Helm Charts configuration file `values.yaml`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the configuration and documentation for integrating container runtimes, specifically focusing on `containerd`. The main changes involve specifying CRI plugin details, updating configuration file paths, and refining the structure for how containerd is used in the system.

**Containerd Runtime Integration:**

* Updated the `containerRuntime` configuration to explicitly set the `configPath` to `/etc/containerd/config.toml` and the `criPluginId` to `io.containerd.cri.v1.images`, ensuring the correct plugin is used.
* Added the `proxyAllRegistries: true` setting in the containerd configuration to enable proxying for all registries.

**Documentation and Structure:**

* Clarified the documentation to specify the use of Helm Charts for deployment and the creation of the `values.yaml` configuration file.
* Improved the breakdown of repository and client configuration sections, making it easier to understand the relationships between components like `dragonflyoss`, `scheduler`, and `dfinit`.

These changes help ensure that the containerd runtime is configured consistently and that deployment instructions are clear and up-to-date.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
