### PR TITLE
docs: add backToSourceConcurrentPieceCount for dfdaemon

### DIFF
--- a/docs/operations/deployment/deployment-best-practices.md
+++ b/docs/operations/deployment/deployment-best-practices.md
@@ -93,7 +93,7 @@ Please refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.
 
 ```yaml
 upload:
-  # -- bandwidthLimit is the default bandwidth limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
+  # bandwidthLimit is the default bandwidth limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
   bandwidthLimit: 50GB
 ```
 
@@ -107,7 +107,7 @@ Please refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.
 
 ```yaml
 download:
-  # -- bandwidthLimit is the default bandwidth limit of the download speed in KB/MB/GB per second, default is 50GB/s.
+  # bandwidthLimit is the default bandwidth limit of the download speed in KB/MB/GB per second, default is 50GB/s.
   bandwidthLimit: 50GB
 ```
 
@@ -122,8 +122,10 @@ Please refer to [dfdaemon config](../../reference/configuration/client/dfdaemon.
 
 ```yaml
 download:
-  # -- concurrentPieceCount is the number of concurrent pieces to download.
-  concurrentPieceCount: 10
+  # concurrentPieceCount is the number of concurrent pieces to download.
+  concurrentPieceCount: 8
+  # backToSourceConcurrentPieceCount is the number of concurrent pieces to download from source.
+  backToSourceConcurrentPieceCount: 8
 ```
 
 ### GC

--- a/docs/reference/configuration/client/dfdaemon.md
+++ b/docs/reference/configuration/client/dfdaemon.md
@@ -86,7 +86,9 @@ download:
   # collectedPieceTimeout is the timeout for collecting one piece from the parent in the stream.
   collectedPieceTimeout: 360s
   # concurrentPieceCount is the number of concurrent pieces to download.
-  concurrentPieceCount: 32
+  concurrentPieceCount: 8
+  # backToSourceConcurrentPieceCount is the number of concurrent pieces to download from source.
+  backToSourceConcurrentPieceCount: 8
 
 upload:
   server:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the documentation related to configuring download concurrency and bandwidth limits for the client daemon. The main focus is to clarify configuration comments and adjust default values for concurrent downloads, ensuring consistency across deployment best practices and reference documentation.

Configuration updates and documentation improvements:

**Download concurrency settings:**
* Changed the default value of `concurrentPieceCount` from 32 to 8 in `docs/reference/configuration/client/dfdaemon.md` and from 10 to 8 in `docs/operations/deployment/deployment-best-practices.md`. Also added a new configuration option, `backToSourceConcurrentPieceCount`, set to 8 in both files. [[1]](diffhunk://#diff-6bcb2b221ca8805778e2f43d0ffdb612c1601d49156a3d10bf9830e709319e8bL89-R91) [[2]](diffhunk://#diff-2dddae558947b87b483ef901dab3b3bb0c86573c651531ffc53b23ebf447442dL125-R128)

**Bandwidth limit comments:**
* Cleaned up and clarified the comments for `bandwidthLimit` settings in both upload and download sections in `docs/operations/deployment/deployment-best-practices.md` by removing unnecessary comment markers. [[1]](diffhunk://#diff-2dddae558947b87b483ef901dab3b3bb0c86573c651531ffc53b23ebf447442dL96-R96) [[2]](diffhunk://#diff-2dddae558947b87b483ef901dab3b3bb0c86573c651531ffc53b23ebf447442dL110-R110)
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/client/pull/2030
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
